### PR TITLE
fix: SonarCloud project link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=Mockerade) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=mockerade) with quality gate requiring to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%


### PR DESCRIPTION
Corrected the SonarCloud project ID in the documentation.