### PR TITLE
feat: consolidate the usage of `With.Matching`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Mockerade provides flexible argument matching for method setups and verification
 - `With.Out<T>(valueFactory)`: Matches and sets out parameters.
 
 ```csharp
-mock.Setup.AddUser(With<string>.Matching(name => name.StartsWith("A")))
+mock.Setup.AddUser(With.Matching<string>(name => name.StartsWith("A")))
     .Returns(new User(Guid.NewGuid(), "Alicia"));
 
 mock.Setup.TryDelete(With.Any<Guid>(), With.Out<User?>(() => new User(id, "Alice")))

--- a/Source/Mockerade/With.cs
+++ b/Source/Mockerade/With.cs
@@ -13,6 +13,18 @@ public static class With
 	public static Parameter<T> Any<T>() => new AnyParameter<T>();
 
 	/// <summary>
+	///     Matches parameters of type <typeparamref name="T" />, if the <paramref name="predicate" /> returns
+	///     <see langword="true" />
+	/// </summary>
+	public static Parameter<T> Matching<T>(Func<T, bool> predicate)
+		=> new PredicateParameter<T>(predicate);
+
+	private sealed class PredicateParameter<T>(Func<T, bool> predicate) : With.Parameter<T>
+	{
+		protected override bool Matches(T value) => predicate(value);
+	}
+
+	/// <summary>
 	///     Matches any <see langword="out"/> parameter of type <typeparamref name="T" />.
 	/// </summary>
 	public static OutParameter<T> Out<T>(Func<T> setter) => new OutParameter<T>(setter);
@@ -168,23 +180,5 @@ public static class With
 		{
 			return true;
 		}
-	}
-}
-
-/// <summary>
-///     Allows the specification of a matching condition for an argument in a method invocation or setup.
-/// </summary>
-public static class With<T>
-{
-	/// <summary>
-	///     Matches parameters of type <typeparamref name="T" />, if the <paramref name="predicate" /> returns
-	///     <see langword="true" />
-	/// </summary>
-	public static With.Parameter<T> Matching(Func<T, bool> predicate)
-		=> new PredicateParameter(predicate);
-
-	private sealed class PredicateParameter(Func<T, bool> predicate) : With.Parameter<T>
-	{
-		protected override bool Matches(T value) => predicate(value);
 	}
 }

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
@@ -60,6 +60,7 @@ namespace Mockerade
     public static class With
     {
         public static Mockerade.With.Parameter<T> Any<T>() { }
+        public static Mockerade.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
         public static Mockerade.With.InvocationOutParameter<T> Out<T>() { }
         public static Mockerade.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
         public static Mockerade.With.InvocationRefParameter<T> Ref<T>() { }
@@ -103,10 +104,6 @@ namespace Mockerade
             public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
             public override bool Matches(object? value) { }
         }
-    }
-    public static class With<T>
-    {
-        public static Mockerade.With.Parameter<T> Matching(System.Func<T, bool> predicate) { }
     }
 }
 namespace Mockerade.Invocations

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
@@ -60,6 +60,7 @@ namespace Mockerade
     public static class With
     {
         public static Mockerade.With.Parameter<T> Any<T>() { }
+        public static Mockerade.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
         public static Mockerade.With.InvocationOutParameter<T> Out<T>() { }
         public static Mockerade.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
         public static Mockerade.With.InvocationRefParameter<T> Ref<T>() { }
@@ -103,10 +104,6 @@ namespace Mockerade
             public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
             public override bool Matches(object? value) { }
         }
-    }
-    public static class With<T>
-    {
-        public static Mockerade.With.Parameter<T> Matching(System.Func<T, bool> predicate) { }
     }
 }
 namespace Mockerade.Invocations

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
@@ -60,6 +60,7 @@ namespace Mockerade
     public static class With
     {
         public static Mockerade.With.Parameter<T> Any<T>() { }
+        public static Mockerade.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
         public static Mockerade.With.InvocationOutParameter<T> Out<T>() { }
         public static Mockerade.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
         public static Mockerade.With.InvocationRefParameter<T> Ref<T>() { }
@@ -103,10 +104,6 @@ namespace Mockerade
             public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
             public override bool Matches(object? value) { }
         }
-    }
-    public static class With<T>
-    {
-        public static Mockerade.With.Parameter<T> Matching(System.Func<T, bool> predicate) { }
     }
 }
 namespace Mockerade.Invocations

--- a/Tests/Mockerade.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockerade.ExampleTests/ExampleTests.cs
@@ -29,7 +29,7 @@ public class ExampleTests
 		var mock = Mock.For<IExampleRepository>();
 
 		mock.Setup.AddUser(
-				With<string>.Matching(x => x == "Alice"))
+				With.Matching<string>(x => x == "Alice"))
 			.Returns(new User(id, "Alice"));
 
 		var result = mock.Object.AddUser(name);

--- a/Tests/Mockerade.Tests/WithTests.cs
+++ b/Tests/Mockerade.Tests/WithTests.cs
@@ -34,7 +34,7 @@ public sealed class WithTests
 	[InlineData(1, false)]
 	public async Task WithMatching_CheckForNull_ShouldReturnExpectedResult(int? value, bool expectedResult)
 	{
-		With.Parameter<int?> sut = With<int?>.Matching(v => v is null);
+		With.Parameter<int?> sut = With.Matching<int?>(v => v is null);
 
 		bool result = sut.Matches(value);
 
@@ -46,7 +46,7 @@ public sealed class WithTests
 	[InlineData("foo")]
 	public async Task WithMatching_DifferentType_ShouldReturnFalse(object? value)
 	{
-		With.Parameter<int?> sut = With<int?>.Matching(_ => true);
+		With.Parameter<int?> sut = With.Matching<int?>(_ => true);
 
 		bool result = sut.Matches(value);
 
@@ -58,7 +58,7 @@ public sealed class WithTests
 	[InlineData(false)]
 	public async Task WithMatching_ShouldReturnPredicateValue(bool predicateValue)
 	{
-		With.Parameter<string> sut = With<string>.Matching(_ => predicateValue);
+		With.Parameter<string> sut = With.Matching<string>(_ => predicateValue);
 
 		bool result = sut.Matches("foo");
 


### PR DESCRIPTION
This PR consolidates the usage of the `With.Matching` method by moving the generic method from a separate `With<T>` static class into the main `With` static class, simplifying the API surface and providing a more consistent interface.

### Key changes:
- Moved `Matching<T>` method from `With<T>` class to `With` class
- Updated all usages from `With<T>.Matching(...)` to `With.Matching<T>(...)`
- Removed the entire `With<T>` static class