### PR TITLE
feat: add conditions for `CheckResult`

### DIFF
--- a/Source/Mockerade/Checks/CheckResult.cs
+++ b/Source/Mockerade/Checks/CheckResult.cs
@@ -17,37 +17,37 @@ public class CheckResult : ICheckResult
 	Invocation[] ICheckResult.Invocations => _invocations;
 
 	/// <summary>
-	/// … at least the expected number of <paramref name="times" />.
+	/// …at least the expected number of <paramref name="times" />.
 	/// </summary>
 	public bool AtLeast(int times) => _invocations.Length >= times;
 
 	/// <summary>
-	/// … at least once.
+	/// …at least once.
 	/// </summary>
 	public bool AtLeastOnce() => _invocations.Length >= 1;
 
 	/// <summary>
-	/// … at most the expected number of <paramref name="times" />.
+	/// …at most the expected number of <paramref name="times" />.
 	/// </summary>
 	public bool AtMost(int times) => _invocations.Length <= times;
 
 	/// <summary>
-	/// … at most once.
+	/// …at most once.
 	/// </summary>
 	public bool AtMostOnce() => _invocations.Length <= 1;
 
 	/// <summary>
-	/// … exactly the expected number of <paramref name="times" />.
+	/// …exactly the expected number of <paramref name="times" />.
 	/// </summary>
 	public bool Exactly(int times) => _invocations.Length == times;
 
 	/// <summary>
-	/// … exatly once.
+	/// …exactly once.
 	/// </summary>
 	public bool Once() => _invocations.Length == 1;
 
 	/// <summary>
-	/// … never.
+	/// …never.
 	/// </summary>
 	public bool Never() => _invocations.Length == 0;
 

--- a/Source/Mockerade/Checks/CheckResult.cs
+++ b/Source/Mockerade/Checks/CheckResult.cs
@@ -3,12 +3,53 @@
 /// <summary>
 ///     The expectation contains the matching invocations for verification.
 /// </summary>
-public class CheckResult(Invocation[] invocations)
+public class CheckResult : ICheckResult
 {
+	private readonly Invocation[] _invocations;
+
+	/// <inheritdoc cref="CheckResult" />
+	public CheckResult(Invocation[] invocations)
+	{
+		this._invocations = invocations;
+	}
+
+	/// <inheritdoc cref="ICheckResult.Invocations" />
+	Invocation[] ICheckResult.Invocations => _invocations;
+
 	/// <summary>
-	///     The matching invocations.
+	/// … at least the expected number of <paramref name="times" />.
 	/// </summary>
-	public Invocation[] Invocations { get; } = invocations;
+	public bool AtLeast(int times) => _invocations.Length >= times;
+
+	/// <summary>
+	/// … at least once.
+	/// </summary>
+	public bool AtLeastOnce() => _invocations.Length >= 1;
+
+	/// <summary>
+	/// … at most the expected number of <paramref name="times" />.
+	/// </summary>
+	public bool AtMost(int times) => _invocations.Length <= times;
+
+	/// <summary>
+	/// … at most once.
+	/// </summary>
+	public bool AtMostOnce() => _invocations.Length <= 1;
+
+	/// <summary>
+	/// … exactly the expected number of <paramref name="times" />.
+	/// </summary>
+	public bool Exactly(int times) => _invocations.Length == times;
+
+	/// <summary>
+	/// … exatly once.
+	/// </summary>
+	public bool Once() => _invocations.Length == 1;
+
+	/// <summary>
+	/// … never.
+	/// </summary>
+	public bool Never() => _invocations.Length == 0;
 
 	/// <summary>
 	///     A property expectation returns the getter or setter <see cref="CheckResult"/> for the given <paramref name="propertyName"/>.

--- a/Source/Mockerade/Checks/ICheckResult.cs
+++ b/Source/Mockerade/Checks/ICheckResult.cs
@@ -1,0 +1,12 @@
+﻿namespace Mockerade.Checks;
+
+/// <summary>
+/// The result of a check containing the matching invocations.
+/// </summary>
+public interface ICheckResult
+{
+	/// <summary>
+	/// The matching invocations.
+	/// </summary>
+	Invocation[] Invocations { get; }
+}

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
@@ -2,16 +2,26 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Mockerade.Checks
 {
-    public class CheckResult
+    public class CheckResult : Mockerade.Checks.ICheckResult
     {
         public CheckResult(Mockerade.Checks.Invocation[] invocations) { }
-        public Mockerade.Checks.Invocation[] Invocations { get; }
+        public bool AtLeast(int times) { }
+        public bool AtLeastOnce() { }
+        public bool AtMost(int times) { }
+        public bool AtMostOnce() { }
+        public bool Exactly(int times) { }
+        public bool Never() { }
+        public bool Once() { }
         public class Property<T>
         {
             public Property(Mockerade.Checks.IMockAccessed mockAccessed, string propertyName) { }
             public Mockerade.Checks.CheckResult Getter() { }
             public Mockerade.Checks.CheckResult Setter(Mockerade.With.Parameter<T> value) { }
         }
+    }
+    public interface ICheckResult
+    {
+        Mockerade.Checks.Invocation[] Invocations { get; }
     }
     public interface IMockAccessed
     {

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
@@ -2,16 +2,26 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Mockerade.Checks
 {
-    public class CheckResult
+    public class CheckResult : Mockerade.Checks.ICheckResult
     {
         public CheckResult(Mockerade.Checks.Invocation[] invocations) { }
-        public Mockerade.Checks.Invocation[] Invocations { get; }
+        public bool AtLeast(int times) { }
+        public bool AtLeastOnce() { }
+        public bool AtMost(int times) { }
+        public bool AtMostOnce() { }
+        public bool Exactly(int times) { }
+        public bool Never() { }
+        public bool Once() { }
         public class Property<T>
         {
             public Property(Mockerade.Checks.IMockAccessed mockAccessed, string propertyName) { }
             public Mockerade.Checks.CheckResult Getter() { }
             public Mockerade.Checks.CheckResult Setter(Mockerade.With.Parameter<T> value) { }
         }
+    }
+    public interface ICheckResult
+    {
+        Mockerade.Checks.Invocation[] Invocations { get; }
     }
     public interface IMockAccessed
     {

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
@@ -2,16 +2,26 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Mockerade.Checks
 {
-    public class CheckResult
+    public class CheckResult : Mockerade.Checks.ICheckResult
     {
         public CheckResult(Mockerade.Checks.Invocation[] invocations) { }
-        public Mockerade.Checks.Invocation[] Invocations { get; }
+        public bool AtLeast(int times) { }
+        public bool AtLeastOnce() { }
+        public bool AtMost(int times) { }
+        public bool AtMostOnce() { }
+        public bool Exactly(int times) { }
+        public bool Never() { }
+        public bool Once() { }
         public class Property<T>
         {
             public Property(Mockerade.Checks.IMockAccessed mockAccessed, string propertyName) { }
             public Mockerade.Checks.CheckResult Getter() { }
             public Mockerade.Checks.CheckResult Setter(Mockerade.With.Parameter<T> value) { }
         }
+    }
+    public interface ICheckResult
+    {
+        Mockerade.Checks.Invocation[] Invocations { get; }
     }
     public interface IMockAccessed
     {

--- a/Tests/Mockerade.ExampleTests/ExampleTests.cs
+++ b/Tests/Mockerade.ExampleTests/ExampleTests.cs
@@ -17,7 +17,7 @@ public class ExampleTests
 		var result = mock.Object.AddUser("Bob");
 
 		await That(result).IsEqualTo(new User(id, "Alice"));
-		await That(mock.Invoked.AddUser("Bob").Invocations).HasCount(1);
+		await That(mock.Invoked.AddUser("Bob").Once()).IsTrue();
 	}
 
 	[Theory]
@@ -35,7 +35,7 @@ public class ExampleTests
 		var result = mock.Object.AddUser(name);
 
 		await That(result).IsEqualTo(expectResult ? new User(id, "Alice") : null);
-		await That(mock.Invoked.AddUser(name).Invocations).HasCount(1);
+		await That(mock.Invoked.AddUser(name).Once()).IsTrue();
 	}
 
 	[Theory]
@@ -55,7 +55,7 @@ public class ExampleTests
 
 		await That(deletedUser).IsEqualTo(new User(id, "Alice"));
 		await That(result).IsEqualTo(returnValue);
-		await That(mock.Invoked.TryDelete(id, With.Out<User?>()).Invocations).HasCount(1);
+		await That(mock.Invoked.TryDelete(id, With.Out<User?>()).Once()).IsTrue();
 	}
 
 	[Fact]
@@ -97,7 +97,7 @@ public class ExampleTests
 		var result = mock.ObjectForIOrderRepository.AddOrder("foo");
 		
 		await That(result.Name).IsEqualTo("Order1");
-		await That(mock.InvokedOnIOrderRepository.AddOrder("foo").Invocations).HasCount(1);
+		await That(mock.InvokedOnIOrderRepository.AddOrder("foo").Once()).IsTrue();
 		await That(mock.Object).Is<IExampleRepository>();
 		await That(mock.Object).Is<IOrderRepository>();
 	}

--- a/Tests/Mockerade.Tests/Checks/CheckResultTests.cs
+++ b/Tests/Mockerade.Tests/Checks/CheckResultTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Mockerade.Checks;
+
+namespace Mockerade.Tests.Checks;
+
+public class CheckResultTests
+{
+	[Theory]
+	[InlineData(0, 0, true)]
+	[InlineData(2, 3, false)]
+	[InlineData(2, 2, true)]
+	[InlineData(2, 1, true)]
+	public async Task AtLeast_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.AtLeast(times);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, false)]
+	[InlineData(1, true)]
+	[InlineData(2, true)]
+	[InlineData(3, true)]
+	public async Task AtLeastOnce_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.AtLeastOnce();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, 0, true)]
+	[InlineData(2, 1, false)]
+	[InlineData(2, 2, true)]
+	[InlineData(2, 3, true)]
+	public async Task AtMost_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.AtMost(times);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, true)]
+	[InlineData(1, true)]
+	[InlineData(2, false)]
+	[InlineData(3, false)]
+	public async Task AtMostOnce_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.AtMostOnce();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, 0, true)]
+	[InlineData(2, 3, false)]
+	[InlineData(2, 2, true)]
+	[InlineData(2, 1, false)]
+	public async Task Exactly_ShouldReturnExpectedResult(int count, int times, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.Exactly(times);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, true)]
+	[InlineData(1, false)]
+	[InlineData(2, false)]
+	[InlineData(3, false)]
+	public async Task Never_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.Never();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(0, false)]
+	[InlineData(1, true)]
+	[InlineData(2, false)]
+	[InlineData(3, false)]
+	public async Task Once_ShouldReturnExpectedResult(int count, bool expectedResult)
+	{
+		var invocations = Enumerable.Range(0, count)
+			.Select(_ => new Invocation())
+			.ToArray();
+		var sut = new CheckResult(invocations);
+
+		var result = sut.Once();
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+}


### PR DESCRIPTION
This PR adds condition methods to the `CheckResult` class to provide a more fluent API for verifying mock invocations. Instead of checking invocation counts manually, users can now use descriptive methods like `Once()`, `Never()`, `AtLeast()`, etc.

### Key changes:
- Added condition methods (`AtLeast`, `AtLeastOnce`, `AtMost`, `AtMostOnce`, `Exactly`, `Once`, `Never`) to `CheckResult`
- Introduced `ICheckResult` interface to expose the `Invocations` property
- Updated example tests to use the new fluent condition methods instead of collection count assertions