### PR TITLE
refactor: improve test coverage for `With`

### DIFF
--- a/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.ExtensionsClass.cs
+++ b/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.ExtensionsClass.cs
@@ -251,8 +251,8 @@ internal static partial class SourceGeneration
 				}
 				sb.Append(parameter.RefKind switch
 				{
-					RefKind.Ref => "With.InvocationRefParameter<",
-					RefKind.Out => "With.InvocationOutParameter<",
+					RefKind.Ref => "With.InvokedRefParameter<",
+					RefKind.Out => "With.InvokedOutParameter<",
 					_ => "With.Parameter<"
 				}).Append(parameter.Type.GetMinimizedString(namespaces))
 					.Append("> ").Append(parameter.Name);

--- a/Source/Mockerade/With.cs
+++ b/Source/Mockerade/With.cs
@@ -3,56 +3,55 @@ using System;
 namespace Mockerade;
 
 /// <summary>
-///     Allows the specification of a matching condition for an argument in a method invocation or setup.
+///     Specify a matching condition for a method parameter.
 /// </summary>
 public static class With
 {
 	/// <summary>
 	///     Matches any parameter of type <typeparamref name="T" />.
 	/// </summary>
-	public static Parameter<T> Any<T>() => new AnyParameter<T>();
+	/// <remarks>Also matches, if the method parameter is <see langword="null" />.</remarks>
+	public static Parameter<T> Any<T>()
+		=> new AnyParameter<T>();
 
 	/// <summary>
-	///     Matches parameters of type <typeparamref name="T" />, if the <paramref name="predicate" /> returns
-	///     <see langword="true" />
+	///     Matches a parameter of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static Parameter<T> Matching<T>(Func<T, bool> predicate)
 		=> new PredicateParameter<T>(predicate);
 
-	private sealed class PredicateParameter<T>(Func<T, bool> predicate) : With.Parameter<T>
-	{
-		protected override bool Matches(T value) => predicate(value);
-	}
+	/// <summary>
+	///     Matches any <see langword="out"/> parameter of type <typeparamref name="T" /> and
+	///     uses the <paramref name="setter"/> to set the value when the method is invoked.
+	/// </summary>
+	public static OutParameter<T> Out<T>(Func<T> setter)
+		=> new OutParameter<T>(setter);
 
 	/// <summary>
 	///     Matches any <see langword="out"/> parameter of type <typeparamref name="T" />.
 	/// </summary>
-	public static OutParameter<T> Out<T>(Func<T> setter) => new OutParameter<T>(setter);
+	public static InvokedOutParameter<T> Out<T>()
+		=> new InvokedOutParameter<T>();
 
 	/// <summary>
-	///     Matches any <see langword="out"/> parameter of type <typeparamref name="T" />.
+	///     Matches any <see langword="ref"/> parameter of type <typeparamref name="T" /> and
+	///     uses the <paramref name="setter"/> to set the value when the method is invoked.
 	/// </summary>
-	public static InvocationOutParameter<T> Out<T>() => new InvocationOutParameter<T>();
+	public static RefParameter<T> Ref<T>(Func<T, T> setter)
+		=> new RefParameter<T>(_ => true, setter);
+
+	/// <summary>
+	///     Matches a <see langword="ref"/> parameter of type <typeparamref name="T" /> that satisfies the <paramref name="predicate"/> and
+	///     uses the <paramref name="setter"/> to set the value when the method is invoked.
+	/// </summary>
+	public static RefParameter<T> Ref<T>(Func<T, bool> predicate, Func<T, T> setter)
+		=> new RefParameter<T>(predicate, setter);
 
 	/// <summary>
 	///     Matches any <see langword="ref"/> parameter of type <typeparamref name="T" />.
 	/// </summary>
-	public static InvocationRefParameter<T> Ref<T>() => new InvocationRefParameter<T>();
-
-	/// <summary>
-	///     Matches any <see langword="ref"/> parameter of type <typeparamref name="T" />.
-	/// </summary>
-	public static RefParameter<T> Ref<T>(Func<T, T> setter) => new RefParameter<T>(_ => true, setter);
-
-	/// <summary>
-	///     Matches any <see langword="ref"/> parameter of type <typeparamref name="T" />.
-	/// </summary>
-	public static RefParameter<T> Ref<T>(Func<T, bool> predicate, Func<T, T> setter) => new RefParameter<T>(predicate, setter);
-
-	private sealed class AnyParameter<T> : Parameter<T>
-	{
-		protected override bool Matches(T value) => true;
-	}
+	public static InvokedRefParameter<T> Ref<T>()
+		=> new InvokedRefParameter<T>();
 
 	/// <summary>
 	///     Matches a method parameter against an expectation.
@@ -60,28 +59,26 @@ public static class With
 	public abstract class Parameter
 	{
 		/// <summary>
-		///     <see langword="true" />, if the <paramref name="value" /> matches the expectation;
-		///     otherwise <see langword="false" />
+		///     Checks if the <paramref name="value" /> is a matching parameter.
 		/// </summary>
+		/// <returns>
+		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter; otherwise <see langword="false" />.
+		/// </returns>
 		public abstract bool Matches(object? value);
 	}
 
 	/// <summary>
-	///     A named <see cref="Parameter"/>.
-	/// </summary>
-	/// <param name="Name">The name of the <paramref name="Parameter"/>.</param>
-	/// <param name="Parameter">The actual <see cref="Parameter"/>.</param>
-	public record NamedParameter(string Name, Parameter Parameter);
-
-	/// <summary>
-	///     Matches a method parameter against an expectation.
+	///     Matches a method parameter of type <typeparamref name="T" /> against an expectation.
 	/// </summary>
 	public abstract class Parameter<T> : Parameter
 	{
 		/// <summary>
-		///     <see langword="true" />, if the <paramref name="value" /> is of type <typeparamref name="T" /> and
-		///     matches the expectation; otherwise <see langword="false" />
+		///     Checks if the <paramref name="value" /> is a matching parameter.
 		/// </summary>
+		/// <returns>
+		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
+		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
+		/// </returns>
 		public override bool Matches(object? value)
 		{
 			if (value is T typedValue)
@@ -93,23 +90,23 @@ public static class With
 		}
 
 		/// <summary>
-		///     Verifies the expectation.
+		///     Verifies the expectation for the <paramref name="value"/>.
 		/// </summary>
 		protected abstract bool Matches(T value);
 
 		/// <summary>
-		///     Implicitly converts to a <see cref="Parameter{T}" /> the compares the <paramref name="value" /> for equality.
+		///     Implicitly converts to a <see cref="Parameter{T}" /> that compares the <paramref name="value" /> for equality.
 		/// </summary>
 		public static implicit operator Parameter<T>(T value)
 		{
-			return new MatchParameterIsEqual(value);
+			return new ParameterEquals(value);
 		}
 
-		private sealed class MatchParameterIsEqual : Parameter<T>
+		private sealed class ParameterEquals : Parameter<T>
 		{
 			private readonly T _value;
 
-			public MatchParameterIsEqual(T value)
+			public ParameterEquals(T value)
 			{
 				_value = value;
 			}
@@ -119,47 +116,72 @@ public static class With
 	}
 
 	/// <summary>
+	///     Matches an <see langword="out"/> parameter against an expectation.
+	/// </summary>
+	public class OutParameter<T>(Func<T> setter) : Parameter
+	{
+		/// <summary>
+		///     Checks if the <paramref name="value" /> is a matching parameter.
+		/// </summary>
+		/// <returns>
+		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
+		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
+		/// </returns>
+		public override bool Matches(object? value)
+		{
+			return true;
+		}
+
+		/// <summary>
+		///     Retrieves the value to which the <see langword="out"/> parameter should be set.
+		/// </summary>
+		public T GetValue() => setter();
+	}
+
+	/// <summary>
+	///     Matches any <see langword="out"/> parameter.
+	/// </summary>
+	public class InvokedOutParameter<T>() : Parameter
+	{
+		/// <summary>
+		///     Matches any <paramref name="value"/>.
+		/// </summary>
+		public override bool Matches(object? value)
+		{
+			return true;
+		}
+	}
+
+	/// <summary>
 	///     Matches a method <see langword="ref"/> parameter against an expectation.
 	/// </summary>
 	public class RefParameter<T>(Func<T, bool> predicate, Func<T, T> setter) : Parameter
 	{
 		/// <summary>
-		///     <see langword="true" />, if the <paramref name="value" /> is of type <typeparamref name="T" /> and
-		///     matches the expectation; otherwise <see langword="false" />
+		///     Checks if the <paramref name="value" /> is a matching parameter.
 		/// </summary>
+		/// <returns>
+		///     <see langword="true" />, if the <paramref name="value" /> is a matching parameter
+		///     of type <typeparamref name="T" />; otherwise <see langword="false" />.
+		/// </returns>
 		public override bool Matches(object? value)
 		{
 			return value is T typedValue && predicate(typedValue);
 		}
 
-		internal T GetValue(T value) => setter(value);
-	}
-
-	/// <summary>
-	///     Matches a method <see langword="out"/> parameter against an expectation.
-	/// </summary>
-	public class OutParameter<T>(Func<T> setter) : Parameter
-	{
 		/// <summary>
-		///     <see langword="true" />, if the <paramref name="value" /> is of type <typeparamref name="T" /> and
-		///     matches the expectation; otherwise <see langword="false" />
+		///     Retrieves the value to which the <see langword="ref"/> parameter should be set.
 		/// </summary>
-		public override bool Matches(object? value)
-		{
-			return true;
-		}
-
-		internal T GetValue() => setter();
+		public T GetValue(T value) => setter(value);
 	}
 
 	/// <summary>
 	///     Matches a method <see langword="out"/> parameter against an expectation.
 	/// </summary>
-	public class InvocationOutParameter<T>() : Parameter
+	public class InvokedRefParameter<T>() : Parameter
 	{
 		/// <summary>
-		///     <see langword="true" />, if the <paramref name="value" /> is of type <typeparamref name="T" /> and
-		///     matches the expectation; otherwise <see langword="false" />
+		///     Matches any <paramref name="value"/>.
 		/// </summary>
 		public override bool Matches(object? value)
 		{
@@ -168,17 +190,19 @@ public static class With
 	}
 
 	/// <summary>
-	///     Matches a method <see langword="out"/> parameter against an expectation.
+	///     A named <see cref="Parameter"/>.
 	/// </summary>
-	public class InvocationRefParameter<T>() : Parameter
+	/// <param name="Name">The name of the <paramref name="Parameter"/>.</param>
+	/// <param name="Parameter">The actual <see cref="Parameter"/>.</param>
+	public record NamedParameter(string Name, Parameter Parameter);
+
+	private sealed class AnyParameter<T> : Parameter<T>
 	{
-		/// <summary>
-		///     <see langword="true" />, if the <paramref name="value" /> is of type <typeparamref name="T" /> and
-		///     matches the expectation; otherwise <see langword="false" />
-		/// </summary>
-		public override bool Matches(object? value)
-		{
-			return true;
-		}
+		protected override bool Matches(T value) => true;
+	}
+
+	private sealed class PredicateParameter<T>(Func<T, bool> predicate) : With.Parameter<T>
+	{
+		protected override bool Matches(T value) => predicate(value);
 	}
 }

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
@@ -53,19 +53,19 @@ namespace Mockerade
     {
         public static Mockerade.With.Parameter<T> Any<T>() { }
         public static Mockerade.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
-        public static Mockerade.With.InvocationOutParameter<T> Out<T>() { }
+        public static Mockerade.With.InvokedOutParameter<T> Out<T>() { }
         public static Mockerade.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
-        public static Mockerade.With.InvocationRefParameter<T> Ref<T>() { }
+        public static Mockerade.With.InvokedRefParameter<T> Ref<T>() { }
         public static Mockerade.With.RefParameter<T> Ref<T>(System.Func<T, T> setter) { }
         public static Mockerade.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
-        public class InvocationOutParameter<T> : Mockerade.With.Parameter
+        public class InvokedOutParameter<T> : Mockerade.With.Parameter
         {
-            public InvocationOutParameter() { }
+            public InvokedOutParameter() { }
             public override bool Matches(object? value) { }
         }
-        public class InvocationRefParameter<T> : Mockerade.With.Parameter
+        public class InvokedRefParameter<T> : Mockerade.With.Parameter
         {
-            public InvocationRefParameter() { }
+            public InvokedRefParameter() { }
             public override bool Matches(object? value) { }
         }
         public class NamedParameter : System.IEquatable<Mockerade.With.NamedParameter>
@@ -77,6 +77,7 @@ namespace Mockerade
         public class OutParameter<T> : Mockerade.With.Parameter
         {
             public OutParameter(System.Func<T> setter) { }
+            public T GetValue() { }
             public override bool Matches(object? value) { }
         }
         public abstract class Parameter
@@ -94,6 +95,7 @@ namespace Mockerade
         public class RefParameter<T> : Mockerade.With.Parameter
         {
             public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+            public T GetValue(T value) { }
             public override bool Matches(object? value) { }
         }
     }

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
@@ -53,19 +53,19 @@ namespace Mockerade
     {
         public static Mockerade.With.Parameter<T> Any<T>() { }
         public static Mockerade.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
-        public static Mockerade.With.InvocationOutParameter<T> Out<T>() { }
+        public static Mockerade.With.InvokedOutParameter<T> Out<T>() { }
         public static Mockerade.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
-        public static Mockerade.With.InvocationRefParameter<T> Ref<T>() { }
+        public static Mockerade.With.InvokedRefParameter<T> Ref<T>() { }
         public static Mockerade.With.RefParameter<T> Ref<T>(System.Func<T, T> setter) { }
         public static Mockerade.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
-        public class InvocationOutParameter<T> : Mockerade.With.Parameter
+        public class InvokedOutParameter<T> : Mockerade.With.Parameter
         {
-            public InvocationOutParameter() { }
+            public InvokedOutParameter() { }
             public override bool Matches(object? value) { }
         }
-        public class InvocationRefParameter<T> : Mockerade.With.Parameter
+        public class InvokedRefParameter<T> : Mockerade.With.Parameter
         {
-            public InvocationRefParameter() { }
+            public InvokedRefParameter() { }
             public override bool Matches(object? value) { }
         }
         public class NamedParameter : System.IEquatable<Mockerade.With.NamedParameter>
@@ -77,6 +77,7 @@ namespace Mockerade
         public class OutParameter<T> : Mockerade.With.Parameter
         {
             public OutParameter(System.Func<T> setter) { }
+            public T GetValue() { }
             public override bool Matches(object? value) { }
         }
         public abstract class Parameter
@@ -94,6 +95,7 @@ namespace Mockerade
         public class RefParameter<T> : Mockerade.With.Parameter
         {
             public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+            public T GetValue(T value) { }
             public override bool Matches(object? value) { }
         }
     }

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
@@ -53,19 +53,19 @@ namespace Mockerade
     {
         public static Mockerade.With.Parameter<T> Any<T>() { }
         public static Mockerade.With.Parameter<T> Matching<T>(System.Func<T, bool> predicate) { }
-        public static Mockerade.With.InvocationOutParameter<T> Out<T>() { }
+        public static Mockerade.With.InvokedOutParameter<T> Out<T>() { }
         public static Mockerade.With.OutParameter<T> Out<T>(System.Func<T> setter) { }
-        public static Mockerade.With.InvocationRefParameter<T> Ref<T>() { }
+        public static Mockerade.With.InvokedRefParameter<T> Ref<T>() { }
         public static Mockerade.With.RefParameter<T> Ref<T>(System.Func<T, T> setter) { }
         public static Mockerade.With.RefParameter<T> Ref<T>(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
-        public class InvocationOutParameter<T> : Mockerade.With.Parameter
+        public class InvokedOutParameter<T> : Mockerade.With.Parameter
         {
-            public InvocationOutParameter() { }
+            public InvokedOutParameter() { }
             public override bool Matches(object? value) { }
         }
-        public class InvocationRefParameter<T> : Mockerade.With.Parameter
+        public class InvokedRefParameter<T> : Mockerade.With.Parameter
         {
-            public InvocationRefParameter() { }
+            public InvokedRefParameter() { }
             public override bool Matches(object? value) { }
         }
         public class NamedParameter : System.IEquatable<Mockerade.With.NamedParameter>
@@ -77,6 +77,7 @@ namespace Mockerade
         public class OutParameter<T> : Mockerade.With.Parameter
         {
             public OutParameter(System.Func<T> setter) { }
+            public T GetValue() { }
             public override bool Matches(object? value) { }
         }
         public abstract class Parameter
@@ -94,6 +95,7 @@ namespace Mockerade
         public class RefParameter<T> : Mockerade.With.Parameter
         {
             public RefParameter(System.Func<T, bool> predicate, System.Func<T, T> setter) { }
+            public T GetValue(T value) { }
             public override bool Matches(object? value) { }
         }
     }

--- a/Tests/Mockerade.Tests/WithTests.cs
+++ b/Tests/Mockerade.Tests/WithTests.cs
@@ -32,7 +32,7 @@ public sealed class WithTests
 	[Theory]
 	[InlineData(null, true)]
 	[InlineData(1, false)]
-	public async Task WithMatching_CheckForNull_ShouldReturnExpectedResult(int? value, bool expectedResult)
+	public async Task WithMatching_CheckForNull_ShouldMatchForExpectedResult(int? value, bool expectedResult)
 	{
 		With.Parameter<int?> sut = With.Matching<int?>(v => v is null);
 
@@ -44,7 +44,7 @@ public sealed class WithTests
 	[Theory]
 	[InlineData(42L)]
 	[InlineData("foo")]
-	public async Task WithMatching_DifferentType_ShouldReturnFalse(object? value)
+	public async Task WithMatching_DifferentType_ShouldNotMatch(object? value)
 	{
 		With.Parameter<int?> sut = With.Matching<int?>(_ => true);
 
@@ -56,12 +56,96 @@ public sealed class WithTests
 	[Theory]
 	[InlineData(true)]
 	[InlineData(false)]
-	public async Task WithMatching_ShouldReturnPredicateValue(bool predicateValue)
+	public async Task WithMatching_ShouldMatchForExpectedResult(bool predicateValue)
 	{
 		With.Parameter<string> sut = With.Matching<string>(_ => predicateValue);
 
 		bool result = sut.Matches("foo");
 
 		await That(result).IsEqualTo(predicateValue);
+	}
+
+	[Theory]
+	[InlineData(42L)]
+	[InlineData("foo")]
+	public async Task WithOut_Invoked_ShouldAlwaysMatch(object? value)
+	{
+		With.InvokedOutParameter<int?> sut = With.Out<int?>();
+
+		bool result = sut.Matches(value);
+
+		await That(result).IsTrue();
+	}
+
+	[Theory]
+	[InlineData(42L)]
+	[InlineData("foo")]
+	public async Task WithOut_ShouldAlwaysMatch(object? value)
+	{
+		With.OutParameter<int?> sut = With.Out<int?>(() => null);
+
+		bool result = sut.Matches(value);
+
+		await That(result).IsTrue();
+	}
+
+	[Theory]
+	[InlineData(42)]
+	[InlineData(-2)]
+	public async Task WithOut_ShouldReturnValue(int? value)
+	{
+		With.OutParameter<int?> sut = With.Out(() => value);
+
+		var result = sut.GetValue();
+
+		await That(result).IsEqualTo(value);
+	}
+
+	[Theory]
+	[InlineData(42L)]
+	[InlineData("foo")]
+	public async Task WithRef_Invoked_ShouldAlwaysMatch(object? value)
+	{
+		With.InvokedRefParameter<int?> sut = With.Ref<int?>();
+
+		bool result = sut.Matches(value);
+
+		await That(result).IsTrue();
+	}
+
+	[Theory]
+	[InlineData(42L)]
+	[InlineData("foo")]
+	public async Task WithRef_DifferentType_ShouldNotMatch(object? value)
+	{
+		With.RefParameter<int?> sut = With.Ref<int?>(_ => true, _ => null);
+
+		bool result = sut.Matches(value);
+
+		await That(result).IsFalse();
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task WithRef_ShouldMatchForExpectedResult(bool predicateValue)
+	{
+		With.RefParameter<string> sut = With.Ref<string>(_ => predicateValue, _ => "");
+
+		bool result = sut.Matches("foo");
+
+		await That(result).IsEqualTo(predicateValue);
+	}
+
+	[Theory]
+	[InlineData(42)]
+	[InlineData(-2)]
+	public async Task WithRef_ShouldReturnValue(int? value)
+	{
+		With.RefParameter<int?> sut = With.Ref<int?>(v => v * 2);
+
+		var result = sut.GetValue(value);
+
+		await That(result).IsEqualTo(2 * value);
 	}
 }


### PR DESCRIPTION
This PR improves test coverage for the `With` class by adding comprehensive tests for `Out` and `Ref` parameter matching functionality. The changes also include class name updates from "Invocation" to "Invoked" for consistency.

### Key changes
- Adds test coverage for `With.Out` and `With.Ref` parameter matching methods
- Renames classes from `InvocationOutParameter`/`InvocationRefParameter` to `InvokedOutParameter`/`InvokedRefParameter`
- Updates API test expectations to reflect the new class names and added methods