### PR TITLE
fix: consider `MockBehavior` when accessing a not-setup property

### DIFF
--- a/Source/Mockerade/Events/MockRaises.cs
+++ b/Source/Mockerade/Events/MockRaises.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Mockerade.Checks;
 using Mockerade.Setup;
 

--- a/Source/Mockerade/Exceptions/MockException.cs
+++ b/Source/Mockerade/Exceptions/MockException.cs
@@ -5,15 +5,15 @@ namespace Mockerade.Exceptions;
 /// <summary>
 ///     Represents the base class for exceptions thrown by mock objects during unit testing.
 /// </summary>
-public abstract class MockException : Exception
+public class MockException : Exception
 {
 	/// <inheritdoc cref="MockException" />
-	protected MockException(string message) : base(message)
+	public MockException(string message) : base(message)
 	{
 	}
 
 	/// <inheritdoc cref="MockException" />
-	protected MockException(string message, Exception innerException) : base(message, innerException)
+	public MockException(string message, Exception innerException) : base(message, innerException)
 	{
 	}
 }

--- a/Source/Mockerade/IMock.cs
+++ b/Source/Mockerade/IMock.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reflection;
-using Mockerade.Checks;
+﻿using Mockerade.Checks;
 using Mockerade.Events;
 using Mockerade.Setup;
 
@@ -32,7 +30,7 @@ public interface IMock
 	void Set(string propertyName, object? value);
 
 	/// <summary>
-	/// Gets the behavior settings used by this mock instance.
+	///     Gets the behavior settings used by this mock instance.
 	/// </summary>
 	MockBehavior Behavior { get; }
 

--- a/Source/Mockerade/Mock.cs
+++ b/Source/Mockerade/Mock.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Reflection;
 using Mockerade.Checks;
 using Mockerade.Events;
 using Mockerade.Exceptions;
@@ -18,10 +17,10 @@ public abstract class Mock<T> : IMock
 	protected Mock(MockBehavior behavior)
 	{
 		_behavior = behavior;
-		Invoked = new MockInvoked<T>(((IMock)this).Invocations);
+		Setup = new MockSetups<T>(this);
 		Accessed = new MockAccessed<T>(((IMock)this).Invocations);
 		Event = new MockEvent<T>(((IMock)this).Invocations);
-		Setup = new MockSetups<T>(this);
+		Invoked = new MockInvoked<T>(((IMock)this).Invocations);
 		Raise = new MockRaises<T>(Setup, ((IMock)this).Invocations);
 	}
 
@@ -43,7 +42,7 @@ public abstract class Mock<T> : IMock
 	/// <summary>
 	///     Check which events were subscribed or unsubscribed on the mocked instance for <typeparamref name="T"/>.
 	/// </summary>
-	public MockEvent<T> Event { get; private set; }
+	public MockEvent<T> Event { get; }
 
 	/// <summary>
 	///     Exposes the mocked object instance of type <typeparamref name="T"/>.
@@ -63,13 +62,16 @@ public abstract class Mock<T> : IMock
 	#region IMock
 
 	/// <inheritdoc cref="IMock.Check" />
-	IMockInvoked IMock.Check => Invoked;
+	IMockInvoked IMock.Check
+		=> Invoked;
 
 	/// <inheritdoc cref="IMock.Raise" />
-	IMockRaises IMock.Raise => Raise;
+	IMockRaises IMock.Raise
+		=> Raise;
 
 	/// <inheritdoc cref="IMock.Setup" />
-	IMockSetup IMock.Setup => Setup;
+	IMockSetup IMock.Setup
+		=> Setup;
 
 	/// <inheritdoc cref="IMock.Invocations" />
 	MockInvocations IMock.Invocations { get; } = new();
@@ -147,5 +149,9 @@ public abstract class Mock<T, T2> : Mock<T>
 	/// <inheritdoc cref="Mock{T}" />
 	protected Mock(MockBehavior behavior) : base(behavior)
 	{
+		if (!typeof(T2).IsInterface)
+		{
+			throw new MockException($"The second generic type argument '{typeof(T2)}' is no interface.");
+		}
 	}
 }

--- a/Source/Mockerade/Setup/MockSetups.cs
+++ b/Source/Mockerade/Setup/MockSetups.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Mockerade.Checks;
+using Mockerade.Exceptions;
 
 namespace Mockerade.Setup;
 
@@ -122,6 +123,11 @@ public class MockSetups<T>(IMock mock) : IMockSetup
 	{
 		if (!_propertySetups.TryGetValue(propertyName, out PropertySetup? matchingSetup))
 		{
+			if (mock.Behavior.ThrowWhenNotSetup)
+			{
+				throw new MockNotSetupException($"The property '{propertyName}' was accessed without prior setup.");
+			}
+
 			matchingSetup = new PropertySetup.Default();
 			_propertySetups.Add(propertyName, matchingSetup);
 		}

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
@@ -224,10 +224,10 @@ namespace Mockerade.Events
 }
 namespace Mockerade.Exceptions
 {
-    public abstract class MockException : System.Exception
+    public class MockException : System.Exception
     {
-        protected MockException(string message) { }
-        protected MockException(string message, System.Exception innerException) { }
+        public MockException(string message) { }
+        public MockException(string message, System.Exception innerException) { }
     }
     public class MockNotSetupException : Mockerade.Exceptions.MockException
     {

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
@@ -224,10 +224,10 @@ namespace Mockerade.Events
 }
 namespace Mockerade.Exceptions
 {
-    public abstract class MockException : System.Exception
+    public class MockException : System.Exception
     {
-        protected MockException(string message) { }
-        protected MockException(string message, System.Exception innerException) { }
+        public MockException(string message) { }
+        public MockException(string message, System.Exception innerException) { }
     }
     public class MockNotSetupException : Mockerade.Exceptions.MockException
     {

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
@@ -224,10 +224,10 @@ namespace Mockerade.Events
 }
 namespace Mockerade.Exceptions
 {
-    public abstract class MockException : System.Exception
+    public class MockException : System.Exception
     {
-        protected MockException(string message) { }
-        protected MockException(string message, System.Exception innerException) { }
+        public MockException(string message) { }
+        public MockException(string message, System.Exception innerException) { }
     }
     public class MockNotSetupException : Mockerade.Exceptions.MockException
     {

--- a/Tests/Mockerade.Tests/MockTests.Methods.cs
+++ b/Tests/Mockerade.Tests/MockTests.Methods.cs
@@ -1,0 +1,84 @@
+﻿using Mockerade.Exceptions;
+
+namespace Mockerade.Tests;
+
+public sealed partial class MockTests
+{
+	[Theory]
+	[InlineData(2)]
+	[InlineData(42)]
+	public async Task Execute_MethodWithReturnValue_ShouldBeRegistered(int numberOfInvocations)
+	{
+		var sut = Mock.For<IMyService>();
+		sut.Setup.Double(With.Any<int>()).Returns(1);
+
+		for (int i = 0; i < numberOfInvocations; i++)
+		{
+			sut.Object.Double(i);
+		}
+
+		await That(sut.Invoked.Double(With.Any<int>()).Exactly(numberOfInvocations));
+	}
+
+	[Fact]
+	public async Task Execute_WhenNotSetup_ShouldReturnDefaultValue()
+	{
+		var sut = Mock.For<IMyService>();
+
+		var result = sut.Object.Double(3);
+
+		await That(result).IsEqualTo(default(int));
+	}
+
+	[Fact]
+	public async Task Execute_WhenBehaviorIsSetToThrow_ShouldThrowMockNotSetupException()
+	{
+		var sut = Mock.For<IMyService>(MockBehavior.Default with
+		{
+			ThrowWhenNotSetup = true
+		});
+
+		void Act()
+			=> sut.Object.Double(3);
+
+		await That(Act).Throws<MockNotSetupException>()
+			.WithMessage("""
+			             The method 'Mockerade.Tests.IMyService.Double(System.Int32)' was invoked without prior setup.
+			             """);
+	}
+
+	[Theory]
+	[InlineData(2)]
+	[InlineData(42)]
+	public async Task Execute_VoidMethod_ShouldBeRegistered(int numberOfInvocations)
+	{
+		var sut = Mock.For<IMyService>();
+		sut.Setup.SetIsValid(With.Any<bool>());
+
+		for (int i = 0; i < numberOfInvocations; i++)
+		{
+			sut.Object.SetIsValid(i % 2 == 0);
+		}
+
+		await That(sut.Invoked.SetIsValid(With.Any<bool>()).Exactly(numberOfInvocations));
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task Execute_VoidMethod_ShouldThrowMockNotSetupExceptionWhenBehaviorIsSetToThrow(bool throwWhenNotSetup)
+	{
+		var sut = Mock.For<IMyService>(MockBehavior.Default with
+		{
+			ThrowWhenNotSetup = throwWhenNotSetup
+		});
+
+		void Act()
+			=> sut.Object.SetIsValid(true);
+
+		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
+			.WithMessage("""
+			             The method 'Mockerade.Tests.IMyService.SetIsValid(System.Boolean)' was invoked without prior setup.
+			             """);
+	}
+}

--- a/Tests/Mockerade.Tests/MockTests.Properties.cs
+++ b/Tests/Mockerade.Tests/MockTests.Properties.cs
@@ -1,0 +1,108 @@
+﻿using Mockerade.Checks;
+using Mockerade.Exceptions;
+using Mockerade.Setup;
+using Mockerade.Tests.TestHelpers;
+
+namespace Mockerade.Tests;
+
+public sealed partial class MockTests
+{
+	[Fact]
+	public async Task Get_ShouldIncreaseInvocationCountOfGetter()
+	{
+		var sut = Mock.For<IMyService>();
+
+		_ = sut.Object.Counter;
+
+		await That(sut.Accessed.Counter.Getter().Once());
+		await That(sut.Accessed.Counter.Setter(With.Any<int>()).Never());
+	}
+
+	[Fact]
+	public async Task Get_ShouldReturnInitializedValue()
+	{
+		var sut = Mock.For<IMyService>();
+		sut.Setup.Counter.InitializeWith(24);
+
+		var result = sut.Object.Counter;
+
+		await That(result).IsEqualTo(24);
+	}
+
+	[Fact]
+	public async Task Set_ShouldIncreaseInvocationCountOfGetter()
+	{
+		var sut = Mock.For<IMyService>();
+
+		sut.Object.Counter = 42;
+
+		await That(sut.Accessed.Counter.Getter().Never());
+		await That(sut.Accessed.Counter.Setter(With.Any<int>()).Once());
+	}
+
+	[Fact]
+	public async Task Set_ShouldUpdateValueForNextGet()
+	{
+		var sut = Mock.For<IMyService>();
+
+		var result1 = sut.Object.Counter;
+		sut.Object.Counter = 5;
+		var result2 = sut.Object.Counter;
+
+		await That(result1).IsEqualTo(0);
+		await That(result2).IsEqualTo(5);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task Get_ShouldThrowMockNotSetupExceptionWhenBehaviorIsSetToThrow(bool throwWhenNotSetup)
+	{
+		var sut = Mock.For<IMyService>(MockBehavior.Default with
+		{
+			ThrowWhenNotSetup = throwWhenNotSetup
+		});
+
+		void Act()
+			=> _ = sut.Object.IsValid;
+
+		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
+			.WithMessage("""
+			             The property 'Mockerade.Tests.IMyService.IsValid' was accessed without prior setup.
+			             """);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task Set_ShouldThrowMockNotSetupExceptionWhenBehaviorIsSetToThrow(bool throwWhenNotSetup)
+	{
+		var sut = Mock.For<IMyService>(MockBehavior.Default with
+		{
+			ThrowWhenNotSetup = throwWhenNotSetup
+		});
+
+		void Act()
+			=> sut.Object.IsValid = true;
+
+		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
+			.WithMessage("""
+			             The property 'Mockerade.Tests.IMyService.IsValid' was accessed without prior setup.
+			             """);
+	}
+
+	[Fact]
+	public async Task Set_WithNull_ShouldUpdateValueForNextGet()
+	{
+		var sut = Mock.For<IMyService>();
+		sut.Setup.IsValid.InitializeWith(true);
+
+
+		var result1 = sut.Object.IsValid;
+		sut.Object.IsValid = null;
+		var result2 = sut.Object.IsValid;
+
+		await That(result1).IsEqualTo(true);
+		await That(result2).IsEqualTo(null);
+	}
+}

--- a/Tests/Mockerade.Tests/MockTests.Properties.cs
+++ b/Tests/Mockerade.Tests/MockTests.Properties.cs
@@ -97,7 +97,6 @@ public sealed partial class MockTests
 		var sut = Mock.For<IMyService>();
 		sut.Setup.IsValid.InitializeWith(true);
 
-
 		var result1 = sut.Object.IsValid;
 		sut.Object.IsValid = null;
 		var result2 = sut.Object.IsValid;

--- a/Tests/Mockerade.Tests/MockTests.cs
+++ b/Tests/Mockerade.Tests/MockTests.cs
@@ -1,159 +1,19 @@
-﻿using Mockerade.Checks;
-using Mockerade.Setup;
+﻿using Mockerade.Exceptions;
 using Mockerade.Tests.TestHelpers;
 
 namespace Mockerade.Tests;
 
-public class MockTests
+public sealed partial class MockTests
 {
 	[Fact]
-	public async Task Execute_MethodWithoutReturnValue_ShouldIncreaseInvocationCountOfRegisteredSetup()
+	public async Task Behavior_ShouldBeSet()
 	{
-		var sut = new MyMock<string>("foo");
-		VoidMethodSetup setup = new("my-method");
+		var sut = new MyMock<string>("", MockBehavior.Default with
+		{
+			ThrowWhenNotSetup = true
+		});
 
-		sut.HiddenSetup.RegisterMethod(setup);
-
-		sut.Hidden.Execute("my-method");
-
-		await That(((IMethodSetup)setup).InvocationCount).IsEqualTo(1);
-	}
-
-	[Fact]
-	public async Task
-		Execute_MethodWithReturnValue_ShouldIncreaseInvocationCountOfRegisteredSetupAndReturnRegisteredValue()
-	{
-		var sut = new MyMock<string>("foo");
-		ReturnMethodSetup<int> setup = new("my-method");
-		setup.Returns(42);
-
-		sut.HiddenSetup.RegisterMethod(setup);
-
-		int value = sut.Hidden.Execute<int>("my-method").Result;
-
-		await That(((IMethodSetup)setup).InvocationCount).IsEqualTo(1);
-		await That(value).IsEqualTo(42);
-	}
-
-	[Fact]
-	public async Task Get_ShouldIncreaseInvocationCountOfRegisteredSetupAndReturnRegisteredValue()
-	{
-		var sut = new MyMock<string>("foo");
-		PropertySetup<int> setup = new();
-		setup.InitializeWith(42);
-
-		sut.HiddenSetup.RegisterProperty("my-property", setup);
-
-		int value = sut.Hidden.Get<int>("my-property");
-
-		await That(setup.GetterInvocationCount).IsEqualTo(1);
-		await That(value).IsEqualTo(42);
-	}
-
-	[Fact]
-	public async Task Invocations_ShouldReturnAllInvocations()
-	{
-		MyMock<string> sut = new("foo");
-		sut.HiddenSetup.RegisterMethod(new ReturnMethodSetup<int>("my-method").Returns(0));
-
-		int value = sut.Hidden.Execute<int>("my-method").Result;
-		sut.Hidden.Get<int>("my-get-property");
-		sut.Hidden.Set("my-set-property", 42);
-
-		await That(sut.Hidden.Invocations.Invocations).HasCount(3);
-		await That(sut.Hidden.Invocations.Invocations).HasItem()
-			.Matching<MethodInvocation>(invocation
-				=> invocation.Name == "my-method" && invocation.Parameters.Length == 0);
-		await That(sut.Hidden.Invocations.Invocations).HasItem()
-			.Matching<PropertyGetterInvocation>(invocation => invocation.Name == "my-get-property");
-		await That(sut.Hidden.Invocations.Invocations).HasItem()
-			.Matching<PropertySetterInvocation>(invocation
-				=> invocation.Name == "my-set-property" && Equals(invocation.Value, 42));
-	}
-
-	[Fact]
-	public async Task RegisterMethod_AfterExecution_ShouldThrowNotSupportedException()
-	{
-		var sut = new MyMock<string>("foo");
-		VoidMethodSetup setup = new("my-method");
-
-		sut.Hidden.Execute("my-method");
-
-		void Act() => sut.HiddenSetup.RegisterMethod(setup);
-
-		await That(Act).Throws<NotSupportedException>()
-			.WithMessage("You may not register additional setups after the first usage of the mock");
-		await That(((IMethodSetup)setup).InvocationCount).IsEqualTo(0);
-	}
-
-	[Fact]
-	public async Task RegisterProperty_AfterExecution_ShouldThrowNotSupportedException()
-	{
-		var sut = new MyMock<string>("foo");
-		PropertySetup<int> setup = new();
-
-		sut.Hidden.Execute("my-property");
-
-		void Act() => sut.HiddenSetup.RegisterProperty("my-property", setup);
-
-		await That(Act).Throws<NotSupportedException>()
-			.WithMessage("You may not register additional setups after the first usage of the mock");
-		await That(setup.GetterInvocationCount).IsEqualTo(0);
-		await That(setup.SetterInvocationCount).IsEqualTo(0);
-	}
-
-	[Fact]
-	public async Task Set_ShouldChangeGetValue()
-	{
-		var sut = new MyMock<string>("foo");
-		PropertySetup<int> setup = new();
-		setup.InitializeWith(42);
-
-		sut.HiddenSetup.RegisterProperty("my-property", setup);
-
-		sut.Hidden.Set("my-property", 43);
-		int value = sut.Hidden.Get<int>("my-property");
-
-		await That(value).IsEqualTo(43);
-	}
-
-	[Fact]
-	public async Task Set_ShouldIncreaseInvocationCountOfRegisteredSetupAndReturnRegisteredValue()
-	{
-		var sut = new MyMock<string>("foo");
-		PropertySetup<int> setup = new();
-
-		sut.HiddenSetup.RegisterProperty("my-property", setup);
-
-		sut.Hidden.Set("my-property", 41);
-
-		await That(setup.SetterInvocationCount).IsEqualTo(1);
-	}
-
-	[Fact]
-	public async Task Set_WithNull_ShouldChangeGetValue()
-	{
-		var sut = new MyMock<string>("foo");
-		PropertySetup<int?> setup = new();
-		setup.InitializeWith(42);
-
-		sut.HiddenSetup.RegisterProperty("my-property", setup);
-
-		sut.Hidden.Set("my-property", null);
-		int? value = sut.Hidden.Get<int?>("my-property");
-
-		await That(value).IsNull();
-	}
-
-	[Fact]
-	public async Task Set_WithoutRegisteredSetup_ShouldChangeGetValue()
-	{
-		var sut = new MyMock<string>("foo");
-
-		sut.Hidden.Set("my-unregistered-property", 43);
-		int value = sut.Hidden.Get<int>("my-unregistered-property");
-
-		await That(value).IsEqualTo(43);
+		await That(sut.Hidden.Behavior.ThrowWhenNotSetup).IsTrue();
 	}
 
 	[Fact]
@@ -165,4 +25,31 @@ public class MockTests
 
 		await That(value).IsEqualTo("foo");
 	}
+
+	[Fact]
+	public async Task WithTwoGenericArguments_WhenSecondIsNoInterface_ShouldThrowMockException()
+	{
+		void Act()
+			=> _ = new MyMock<IMyService, MyBaseClass>();
+
+		await That(Act).Throws<MockException>()
+			.WithMessage("""
+			             The second generic type argument 'Mockerade.Tests.MyBaseClass' is no interface.
+			             """);
+	}
+}
+
+public interface IMyService
+{
+	public bool? IsValid { get; set; }
+	public int Counter { get; set; }
+
+	public int Double(int value);
+
+	public void SetIsValid(bool isValid);
+}
+
+public class MyBaseClass
+{
+	public virtual string VirtualMethod() => "Base";
 }

--- a/Tests/Mockerade.Tests/Mockerade.Tests.csproj
+++ b/Tests/Mockerade.Tests/Mockerade.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
+		<ProjectReference Include="..\..\Source\Mockerade.SourceGenerators\Mockerade.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\..\Source\Mockerade\Mockerade.csproj" />
 	</ItemGroup>
 

--- a/Tests/Mockerade.Tests/TestHelpers/MyMock.cs
+++ b/Tests/Mockerade.Tests/TestHelpers/MyMock.cs
@@ -1,10 +1,45 @@
-﻿using Mockerade.Setup;
+﻿using Mockerade.Checks;
+using Mockerade.Events;
+using Mockerade.Setup;
 
 namespace Mockerade.Tests.TestHelpers;
 
-public class MyMock<T>(T @object) : Mock<T>(MockBehavior.Default)
+public class MyMock<T>(T @object, MockBehavior? behavior = null) : Mock<T>(behavior ?? MockBehavior.Default)
 {
-	public IMockSetup HiddenSetup => Setup;
-	public IMock Hidden => this;
+	public IMockAccessed HiddenAccessed
+		=> Accessed;
+
+	public IMockEvent HiddenEvent
+		=> Event;
+
+	public IMockRaises HiddenRaise
+		=> Raise;
+
+	public IMockSetup HiddenSetup
+		=> Setup;
+
+	public IMock Hidden
+		=> this;
+
+	public override T Object => @object;
+}
+
+public class MyMock<T, T2>(T @object = default!, MockBehavior? behavior = null) : Mock<T, T2>(behavior ?? MockBehavior.Default)
+{
+	public IMockAccessed HiddenAccessed
+		=> Accessed;
+
+	public IMockEvent HiddenEvent
+		=> Event;
+
+	public IMockRaises HiddenRaise
+		=> Raise;
+
+	public IMockSetup HiddenSetup
+		=> Setup;
+
+	public IMock Hidden
+		=> this;
+
 	public override T Object => @object;
 }


### PR DESCRIPTION
This PR implements MockBehavior support for property access scenarios in the Mockerade testing library, specifically adding the ability to throw MockNotSetupException when accessing properties that haven't been explicitly set up.

### Key changes:
- Updated MockSetups to check MockBehavior.ThrowWhenNotSetup when accessing unregistered properties
- Modified MockException class visibility from abstract to concrete with public constructors
- Enhanced test coverage with new test files for property and method behavior validation