### PR TITLE
fix: support nested classes or interfaces

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="Mockerade" Version="0.1.0"/>
+		<PackageVersion Include="Mockerade" Version="0.3.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="IsExternalInit" Version="1.0.3" />

--- a/Source/Mockerade.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockerade.SourceGenerators/Entities/Class.cs
@@ -57,10 +57,6 @@ internal record Class
 	internal IEnumerable<string> EnumerateNamespaces()
 	{
 		yield return Namespace;
-		if (ContainingType?.Namespace is not null)
-		{
-			yield return ContainingType.Value.Namespace;
-		}
 		foreach (Method method in Methods)
 		{
 			if (method.ReturnType.Namespace != null)

--- a/Source/Mockerade.SourceGenerators/Entities/Class.cs
+++ b/Source/Mockerade.SourceGenerators/Entities/Class.cs
@@ -10,6 +10,12 @@ internal record Class
 		Namespace = type.ContainingNamespace.ToString();
 		ClassName = type.Name;
 
+		if (type.ContainingType is not null)
+		{
+			ContainingType = new Type(type.ContainingType);
+			ClassName = type.ContainingType.Name + "." + ClassName;
+		}
+
 		IsInterface = type.TypeKind == TypeKind.Interface;
 		Methods = new EquatableArray<Method>(
 			type.GetMembers().OfType<IMethodSymbol>()
@@ -32,6 +38,8 @@ internal record Class
 				.ToArray());
 	}
 
+	public Type? ContainingType { get; }
+
 	public EquatableArray<Method> Methods { get; }
 
 	public EquatableArray<Property> Properties { get; }
@@ -42,10 +50,17 @@ internal record Class
 	public string Namespace { get; }
 	public string ClassName { get; }
 
+	public string GetClassNameWithoutDots()
+		=> ClassName.Replace(".", "");
+
 	public string[] GetClassNamespaces() => EnumerateNamespaces().Distinct().OrderBy(n => n).ToArray();
 	internal IEnumerable<string> EnumerateNamespaces()
 	{
 		yield return Namespace;
+		if (ContainingType?.Namespace is not null)
+		{
+			yield return ContainingType.Value.Namespace;
+		}
 		foreach (Method method in Methods)
 		{
 			if (method.ReturnType.Namespace != null)

--- a/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.ExtensionsClass.cs
+++ b/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.ExtensionsClass.cs
@@ -8,7 +8,7 @@ namespace Mockerade.SourceGenerators.Internals;
 #pragma warning disable S3779 // Cognitive Complexity of methods should not be too high
 internal static partial class SourceGeneration
 {
-	public static string GetExtensionClass(Class @class)
+	public static string GetExtensionClass(string name, Class @class)
 	{
 		string[] namespaces = @class.GetClassNamespaces();
 		StringBuilder sb = new();
@@ -28,7 +28,7 @@ internal static partial class SourceGeneration
 		          #nullable enable
 
 		          """);
-		sb.Append("public static class ExtensionsFor").Append(@class.ClassName).AppendLine();
+		sb.Append("public static class ExtensionsFor").Append(name).AppendLine();
 		sb.AppendLine("{");
 		if (@class.Events.Any())
 		{

--- a/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.RegisterMocks.cs
+++ b/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.RegisterMocks.cs
@@ -51,7 +51,7 @@ internal static partial class SourceGeneration
 			}
 			sb.AppendLine(")");
 			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t_value = new For").Append(mock.Name.Replace('.', '_')).Append(".Mock(constructorParameters, mockBehavior);").AppendLine();
+			sb.Append("\t\t\t\t_value = new For").Append(mock.Name).Append(".Mock(constructorParameters, mockBehavior);").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
 		}
 

--- a/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.RegisterMocks.cs
+++ b/Source/Mockerade.SourceGenerators/Internals/SourceGeneration.RegisterMocks.cs
@@ -51,7 +51,7 @@ internal static partial class SourceGeneration
 			}
 			sb.AppendLine(")");
 			sb.Append("\t\t\t{").AppendLine();
-			sb.Append("\t\t\t\t_value = new For").Append(mock.Name).Append(".Mock(constructorParameters, mockBehavior);").AppendLine();
+			sb.Append("\t\t\t\t_value = new For").Append(mock.Name.Replace('.', '_')).Append(".Mock(constructorParameters, mockBehavior);").AppendLine();
 			sb.Append("\t\t\t}").AppendLine();
 		}
 

--- a/Source/Mockerade.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockerade.SourceGenerators/MockGenerator.cs
@@ -42,8 +42,8 @@ public class MockGenerator : IIncrementalGenerator
 				.Where(t => t is not null)
 				.Cast<ITypeSymbol>()
 				.ToArray();
-			MockClass mockClassClass = new(types);
-			return mockClassClass;
+			MockClass mockClass = new(types);
+			return mockClass;
 		}
 
 		return null;
@@ -56,13 +56,13 @@ public class MockGenerator : IIncrementalGenerator
 		{
 			string result = SourceGeneration.GetMockClass(mockToGenerate.Name, mockToGenerate.MockClass);
 			// Create a separate class file for each mock
-			var fileName = $"For{mockToGenerate.Name}.g.cs";
+			var fileName = $"For{mockToGenerate.Name.Replace('.', '_')}.g.cs";
 			context.AddSource(fileName, SourceText.From(result, Encoding.UTF8));
 		}
 		
 		foreach (var (name, extensionToGenerate) in GetDistinctExtensions(mocksToGenerate))
 		{
-			string result = SourceGeneration.GetExtensionClass(extensionToGenerate);
+			string result = SourceGeneration.GetExtensionClass(name, extensionToGenerate);
 			// Create a separate class file for each mock
 			var fileName = $"ExtensionsFor{name}.g.cs";
 			context.AddSource(fileName, SourceText.From(result, Encoding.UTF8));
@@ -71,9 +71,6 @@ public class MockGenerator : IIncrementalGenerator
 		context.AddSource("MockRegistration.g.cs",
 			SourceText.From(SourceGeneration.RegisterMocks(namedMocksToGenerate), Encoding.UTF8));
 	}
-
-	private static string GetFileName(Class @class)
-		=> $"{@class.Namespace}_{@class.ClassName}".Replace(".", "_");
 
 	private static List<(string Name, Class Class)> GetDistinctExtensions(ImmutableArray<MockClass> mocksToGenerate)
 	{
@@ -84,10 +81,10 @@ public class MockGenerator : IIncrementalGenerator
 			if (classNames.Add((mockToGenerate.Namespace, mockToGenerate.ClassName)))
 			{
 				int suffix = 1;
-				var actualName = mockToGenerate.ClassName;
+				var actualName = mockToGenerate.GetClassNameWithoutDots();
 				while (result.Any(r => r.Name == actualName))
 				{
-					actualName = $"{mockToGenerate.ClassName}_{suffix++}";
+					actualName = $"{mockToGenerate.GetClassNameWithoutDots()}_{suffix++}";
 				}
 				result.Add((actualName, mockToGenerate));
 			}
@@ -96,10 +93,10 @@ public class MockGenerator : IIncrementalGenerator
 				if (classNames.Add((item.Namespace, item.ClassName)))
 				{
 					int suffix = 1;
-					var actualName = item.ClassName;
+					var actualName = item.GetClassNameWithoutDots();
 					while (result.Any(r => r.Name == actualName))
 					{
-						actualName = $"{item.ClassName}_{suffix++}";
+						actualName = $"{item.GetClassNameWithoutDots()}_{suffix++}";
 					}
 					result.Add((actualName, item));
 				}
@@ -114,10 +111,10 @@ public class MockGenerator : IIncrementalGenerator
 		for(int i=0;i< mocksToGenerate.Length; i++)
 		{
 			MockClass mockClass = mocksToGenerate[i];
-			string name = mockClass.ClassName;
+			string name = mockClass.GetClassNameWithoutDots();
 			if (mockClass.AdditionalImplementations.Any())
 			{
-				name += "_" + string.Join("_", mockClass.AdditionalImplementations.Select(t => t.ClassName));
+				name += "_" + string.Join("_", mockClass.AdditionalImplementations.Select(t => t.GetClassNameWithoutDots()));
 			}
 			int suffix = 1;
 			var actualName = name;

--- a/Source/Mockerade.SourceGenerators/MockGenerator.cs
+++ b/Source/Mockerade.SourceGenerators/MockGenerator.cs
@@ -56,7 +56,7 @@ public class MockGenerator : IIncrementalGenerator
 		{
 			string result = SourceGeneration.GetMockClass(mockToGenerate.Name, mockToGenerate.MockClass);
 			// Create a separate class file for each mock
-			var fileName = $"For{mockToGenerate.Name.Replace('.', '_')}.g.cs";
+			var fileName = $"For{mockToGenerate.Name}.g.cs";
 			context.AddSource(fileName, SourceText.From(result, Encoding.UTF8));
 		}
 		

--- a/Source/Mockerade.SourceGenerators/Properties/launchSettings.json
+++ b/Source/Mockerade.SourceGenerators/Properties/launchSettings.json
@@ -3,7 +3,7 @@
 	"profiles": {
 		"Generators": {
 			"commandName": "DebugRoslynComponent",
-			"targetProject": "../../Tests/Mockerade.ExampleTests/Mockerade.ExampleTests.csproj"
+			"targetProject": "../../Tests/Mockerade.Tests/Mockerade.Tests.csproj"
 		}
 	}
 }

--- a/Tests/Mockerade.Tests/MockTests.Methods.cs
+++ b/Tests/Mockerade.Tests/MockTests.Methods.cs
@@ -43,7 +43,7 @@ public sealed partial class MockTests
 
 		await That(Act).Throws<MockNotSetupException>()
 			.WithMessage("""
-			             The method 'Mockerade.Tests.IMyService.Double(System.Int32)' was invoked without prior setup.
+			             The method 'Mockerade.Tests.MockTests.IMyService.Double(System.Int32)' was invoked without prior setup.
 			             """);
 	}
 
@@ -78,7 +78,7 @@ public sealed partial class MockTests
 
 		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
 			.WithMessage("""
-			             The method 'Mockerade.Tests.IMyService.SetIsValid(System.Boolean)' was invoked without prior setup.
+			             The method 'Mockerade.Tests.MockTests.IMyService.SetIsValid(System.Boolean)' was invoked without prior setup.
 			             """);
 	}
 }

--- a/Tests/Mockerade.Tests/MockTests.Properties.cs
+++ b/Tests/Mockerade.Tests/MockTests.Properties.cs
@@ -68,7 +68,7 @@ public sealed partial class MockTests
 
 		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
 			.WithMessage("""
-			             The property 'Mockerade.Tests.IMyService.IsValid' was accessed without prior setup.
+			             The property 'Mockerade.Tests.MockTests.IMyService.IsValid' was accessed without prior setup.
 			             """);
 	}
 
@@ -87,7 +87,7 @@ public sealed partial class MockTests
 
 		await That(Act).Throws<MockNotSetupException>().OnlyIf(throwWhenNotSetup)
 			.WithMessage("""
-			             The property 'Mockerade.Tests.IMyService.IsValid' was accessed without prior setup.
+			             The property 'Mockerade.Tests.MockTests.IMyService.IsValid' was accessed without prior setup.
 			             """);
 	}
 

--- a/Tests/Mockerade.Tests/MockTests.cs
+++ b/Tests/Mockerade.Tests/MockTests.cs
@@ -34,22 +34,22 @@ public sealed partial class MockTests
 
 		await That(Act).Throws<MockException>()
 			.WithMessage("""
-			             The second generic type argument 'Mockerade.Tests.MyBaseClass' is no interface.
+			             The second generic type argument 'Mockerade.Tests.MockTests+MyBaseClass' is no interface.
 			             """);
 	}
-}
 
-public interface IMyService
-{
-	public bool? IsValid { get; set; }
-	public int Counter { get; set; }
+	public interface IMyService
+	{
+		public bool? IsValid { get; set; }
+		public int Counter { get; set; }
 
-	public int Double(int value);
+		public int Double(int value);
 
-	public void SetIsValid(bool isValid);
-}
+		public void SetIsValid(bool isValid);
+	}
 
-public class MyBaseClass
-{
-	public virtual string VirtualMethod() => "Base";
+	public class MyBaseClass
+	{
+		public virtual string VirtualMethod() => "Base";
+	}
 }


### PR DESCRIPTION
This PR adds support for nested classes and interfaces by updating the source generator to correctly handle types contained within other types. The main change involves updating type name generation to include the containing type's name and adjusting file naming to handle dots in nested type names.

### Key changes
- Updates type name handling to include containing type names with dot notation
- Modifies file name generation to replace dots with underscores for valid file names
- Updates test expectations to reflect the new nested type naming format

---

- *Fixes #28*