### PR TITLE
docs: add simple benchmark with other mocking libraries

### DIFF
--- a/.github/workflows/ci-analysis.yml
+++ b/.github/workflows/ci-analysis.yml
@@ -21,7 +21,6 @@ jobs:
                 uses: actions/setup-dotnet@v5
                 with:
                     dotnet-version: |
-                        8.0.x
                         10.0.x
             -   name: Create mutation test comment
                 run: ./build.sh MutationTestComment
@@ -43,7 +42,6 @@ jobs:
                 uses: actions/setup-dotnet@v5
                 with:
                     dotnet-version: |
-                        8.0.x
                         10.0.x
             -   name: Create benchmark comment
                 run: ./build.sh BenchmarkComment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
                     name: Benchmarks
                     path: |
                         ./Artifacts/*
+                    if-no-files-found: ignore
     
     static-code-analysis:
         name: "Static code analysis"

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -38,7 +38,7 @@
         "Compile",
         "DotNetUnitTests",
         "MutationComment",
-        "MutationTestDashboard",
+        "MutationTestComment",
         "MutationTestExecution",
         "MutationTests",
         "Pack",

--- a/Benchmarks/Mockerade.Benchmarks/HappyCaseBenchmarks.Simple.cs
+++ b/Benchmarks/Mockerade.Benchmarks/HappyCaseBenchmarks.Simple.cs
@@ -49,7 +49,7 @@ public partial class HappyCaseBenchmarks
 
 		mock.MyFunc(42);
 
-		mock.Received().MyFunc(Arg.Any<int>());
+		mock.Received(1).MyFunc(Arg.Any<int>());
 	}
 
 	/// <summary>
@@ -63,11 +63,11 @@ public partial class HappyCaseBenchmarks
 
 		mock.MyFunc(42);
 
-		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened();
+		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened(1, Times.Exactly);
 	}
-}
 
-public interface IMyInterface
-{
-	bool MyFunc(int value);
+	public interface IMyInterface
+	{
+		bool MyFunc(int value);
+	}
 }

--- a/Benchmarks/Mockerade.Benchmarks/HappyCaseBenchmarks.Simple.cs
+++ b/Benchmarks/Mockerade.Benchmarks/HappyCaseBenchmarks.Simple.cs
@@ -1,0 +1,73 @@
+﻿using aweXpect;
+using BenchmarkDotNet.Attributes;
+using FakeItEasy;
+using NSubstitute;
+
+namespace Mockerade.Benchmarks;
+
+/// <summary>
+///     In this benchmark we check the simple case of an interface mock, setup a single method that gets called and verified to be called once.<br />
+/// </summary>
+public partial class HappyCaseBenchmarks
+{
+	/// <summary>
+	///     <see href="https://github.com/Mockerade/Mockerade"/>
+	/// </summary>
+	[Benchmark]
+	public async Task Simple_Mockerade()
+	{
+		var mock = Mock.For<IMyInterface>();
+		mock.Setup.MyFunc(With.Any<int>()).Returns(true);
+
+		mock.Object.MyFunc(42);
+
+		await Expect.That(mock.Invoked.MyFunc(With.Any<int>()).Once());
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/devlooped/moq"/>
+	/// </summary>
+	[Benchmark]
+	public void Simple_Moq()
+	{
+		var mock = new Moq.Mock<IMyInterface>();
+		mock.Setup(x => x.MyFunc(Moq.It.IsAny<int>())).Returns(true);
+
+		mock.Object.MyFunc(42);
+
+		mock.Verify(x => x.MyFunc(Moq.It.IsAny<int>()), Moq.Times.Once());
+	}
+
+	/// <summary>
+	///     <see href="https://nsubstitute.github.io/"/>
+	/// </summary>
+	[Benchmark]
+	public void Simple_NSubstitute()
+	{
+		var mock = Substitute.For<IMyInterface>();
+		mock.MyFunc(Arg.Any<int>()).Returns(true);
+
+		mock.MyFunc(42);
+
+		mock.Received().MyFunc(Arg.Any<int>());
+	}
+
+	/// <summary>
+	///     <see href="https://fakeiteasy.github.io/"/>
+	/// </summary>
+	[Benchmark]
+	public void Simple_FakeItEasy()
+	{
+		var mock = A.Fake<IMyInterface>();
+		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).Returns(true);
+
+		mock.MyFunc(42);
+
+		A.CallTo(() => mock.MyFunc(A<int>.Ignored)).MustHaveHappened();
+	}
+}
+
+public interface IMyInterface
+{
+	bool MyFunc(int value);
+}

--- a/Benchmarks/Mockerade.Benchmarks/HappyCaseBenchmarks.cs
+++ b/Benchmarks/Mockerade.Benchmarks/HappyCaseBenchmarks.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+
+namespace Mockerade.Benchmarks;
+
+[Config(typeof(Config))]
+[MarkdownExporterAttribute.GitHub]
+[MemoryDiagnoser]
+public partial class HappyCaseBenchmarks
+{
+	private readonly Consumer _consumer = new();
+
+	private sealed class Config : ManualConfig
+	{
+		public Config()
+		{
+			AddJob(Job.MediumRun
+				.WithLaunchCount(1)
+				.WithToolchain(InProcessEmitToolchain.Instance)
+				.WithId("InProcess"));
+		}
+	}
+}

--- a/Benchmarks/Mockerade.Benchmarks/Mockerade.Benchmarks.csproj
+++ b/Benchmarks/Mockerade.Benchmarks/Mockerade.Benchmarks.csproj
@@ -13,11 +13,12 @@
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet"/>
 		<PackageReference Include="aweXpect"/>
+		<ProjectReference Include="..\..\Source\Mockerade.SourceGenerators\Mockerade.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\..\Source\Mockerade\Mockerade.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Moq"/>
-		<PackageReference Include="Mockerade"/>
 		<PackageReference Include="NSubstitute"/>
 		<PackageReference Include="FakeItEasy"/>
 	</ItemGroup>

--- a/Benchmarks/Mockerade.Benchmarks/Mockerade.Benchmarks.csproj
+++ b/Benchmarks/Mockerade.Benchmarks/Mockerade.Benchmarks.csproj
@@ -12,10 +12,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet"/>
+		<PackageReference Include="aweXpect"/>
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Source\Mockerade\Mockerade.csproj"/>
+		<PackageReference Include="Moq"/>
+		<PackageReference Include="Mockerade"/>
+		<PackageReference Include="NSubstitute"/>
+		<PackageReference Include="FakeItEasy"/>
 	</ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,4 +36,9 @@
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.6"/>
 		<PackageVersion Include="aweXpect" Version="2.26.0"/>
 	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="Moq" Version="4.20.72"/>
+		<PackageVersion Include="NSubstitute" Version="5.3.0"/>
+		<PackageVersion Include="FakeItEasy" Version="8.3.0"/>
+	</ItemGroup>
 </Project>

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -54,6 +54,7 @@ partial class Build
 	Target BenchmarkComment => _ => _
 		.Executes(async () =>
 		{
+			await "Benchmarks".DownloadArtifactTo(ArtifactsDirectory, GithubToken);
 			if (!File.Exists(ArtifactsDirectory / "Benchmarks" / "results" /
 															 "Mockerade.Benchmarks.HappyCaseBenchmarks-report-github.md"))
 			{
@@ -61,7 +62,6 @@ partial class Build
 				return;
 			}
 
-			await "Benchmarks".DownloadArtifactTo(ArtifactsDirectory, GithubToken);
 			if (!File.Exists(ArtifactsDirectory / "PR.txt"))
 			{
 				Log.Information("Skip writing a comment, as no PR number was specified.");


### PR DESCRIPTION
This PR adds benchmark comparisons between Mockerade and other popular .NET mocking libraries ([Moq](https://github.com/devlooped/moq), [NSubstitute](https://nsubstitute.github.io), and [FakeItEasy](https://fakeiteasy.github.io)) to demonstrate performance characteristics.

### Key changes:
- Adds package references for major mocking libraries (Moq, NSubstitute, FakeItEasy)
- Creates benchmark infrastructure with BenchmarkDotNet configuration
- Implements simple interface mocking benchmarks comparing all four libraries

---

- *Fixes #19*