### PR TITLE
feat: use source link

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2"/>
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -29,7 +29,10 @@
 	<PropertyGroup>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>
+		<IncludeSource>true</IncludeSource>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
@@ -42,6 +45,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -45,7 +45,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all"/>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR adds [Source Link](https://github.com/dotnet/sourcelink) support to enable source code navigation and debugging for published NuGet packages. Source Link allows developers to step through the original source code when debugging packages by embedding repository URLs and commit information.

### Key changes
- Added SourceLink configuration properties to enable repository URL publishing and source embedding
- Added Microsoft.SourceLink.GitHub package reference for GitHub repository integration
- Configured symbol package generation to include source code