### PR TITLE
fix: repository URL

### DIFF
--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -77,7 +77,7 @@ partial class Build
 				Credentials tokenAuth = new(GithubToken);
 				gitHubClient.Credentials = tokenAuth;
 				IReadOnlyList<IssueComment> comments =
-					await gitHubClient.Issue.Comment.GetAllForIssue("vbreuss", "Mockerade", prId);
+					await gitHubClient.Issue.Comment.GetAllForIssue("Mockerade", "Mockerade", prId);
 				long? commentId = null;
 				Log.Information($"Found {comments.Count} comments");
 				foreach (IssueComment comment in comments)
@@ -92,12 +92,12 @@ partial class Build
 				if (commentId == null)
 				{
 					Log.Information($"Create comment:\n{body}");
-					await gitHubClient.Issue.Comment.Create("vbreuss", "Mockerade", prId, body);
+					await gitHubClient.Issue.Comment.Create("Mockerade", "Mockerade", prId, body);
 				}
 				else
 				{
 					Log.Information($"Update comment:\n{body}");
-					await gitHubClient.Issue.Comment.Update("vbreuss", "Mockerade", commentId.Value, body);
+					await gitHubClient.Issue.Comment.Update("Mockerade", "Mockerade", commentId.Value, body);
 				}
 			}
 		});

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,7 +7,7 @@
 		<Authors>Mockerade</Authors>
 		<Description>A modern, strongly-typed mocking library for .NET, powered by source generators.</Description>
 		<Copyright>Copyright (c) 2025 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
-		<RepositoryUrl>https://github.com/vbreuss/Mockerade.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Mockerade/Mockerade.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/vbreuss/Mockerade.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Mockerade/Mockerade.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Mockerade
 {

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/vbreuss/Mockerade.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Mockerade/Mockerade.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Mockerade
 {

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/vbreuss/Mockerade.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Mockerade/Mockerade.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Mockerade
 {


### PR DESCRIPTION
This PR updates the repository URL from a personal GitHub account (vbreuss) to an organization account (Mockerade). The change consolidates the project under the Mockerade organization while maintaining the same repository name.

### Key changes:
- Updated repository URL references from `vbreuss/Mockerade` to `Mockerade/Mockerade`
- Modified assembly metadata and build configuration files
- Updated GitHub API calls in pipeline code