### PR TITLE
docs: make "Mockerade" line bold in benchmark result comment

### DIFF
--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -134,7 +134,7 @@ partial class Build
 				continue;
 			}
 
-			if (line.StartsWith('|') && line.Contains("_mockerade") && line.EndsWith('|'))
+			if (line.StartsWith('|') && line.Contains("_Mockerade", StringComparison.OrdinalIgnoreCase) && line.EndsWith('|'))
 			{
 				MakeLineBold(sb, line);
 				continue;


### PR DESCRIPTION
Updates the benchmark result comment formatting to make the "Mockerade" line bold by improving the string matching condition.

- Modified string matching to use case-insensitive comparison and updated the search term from "_mockerade" to "_Mockerade"