### PR TITLE
feat: add `Monitor` to validate only part of the changes

### DIFF
--- a/Source/Mockerade/Checks/MockInvocations.cs
+++ b/Source/Mockerade/Checks/MockInvocations.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 namespace Mockerade.Checks;
 
@@ -12,16 +14,18 @@ public class MockInvocations
 	/// </summary>
 	public bool IsAlreadyInvoked => _invocations.Count > 0;
 
-	private readonly List<Invocation> _invocations = [];
+	private readonly List<(int Index, Invocation Invocation)> _invocations = [];
+	private int _index = 0;
 
 	/// <summary>
 	///     The registered invocations of the mock.
 	/// </summary>
-	public IReadOnlyList<Invocation> Invocations => _invocations.AsReadOnly();
+	public IEnumerable<Invocation> Invocations => _invocations.Select(x => x.Invocation);
 
 	internal Invocation RegisterInvocation(Invocation invocation)
 	{
-		_invocations.Add(invocation);
+		var index = Interlocked.Increment(ref _index);
+		_invocations.Add((index, invocation));
 		return invocation;
 	}
 }

--- a/Source/Mockerade/Checks/MockInvocations.cs
+++ b/Source/Mockerade/Checks/MockInvocations.cs
@@ -10,22 +10,25 @@ namespace Mockerade.Checks;
 public class MockInvocations
 {
 	/// <summary>
-	/// Indicates whether (at least) one invocation was already triggered.
+	///     Indicates whether (at least) one invocation was already triggered.
 	/// </summary>
 	public bool IsAlreadyInvoked => _invocations.Count > 0;
 
-	private readonly List<(int Index, Invocation Invocation)> _invocations = [];
-	private int _index = 0;
+	/// <summary>
+	///     The number of invocations contained in the collection.
+	/// </summary>
+	public int Count => _invocations.Count;
+
+	private readonly List<Invocation> _invocations = [];
 
 	/// <summary>
 	///     The registered invocations of the mock.
 	/// </summary>
-	public IEnumerable<Invocation> Invocations => _invocations.Select(x => x.Invocation);
+	public IEnumerable<Invocation> Invocations => _invocations;
 
 	internal Invocation RegisterInvocation(Invocation invocation)
 	{
-		var index = Interlocked.Increment(ref _index);
-		_invocations.Add((index, invocation));
+		_invocations.Add(invocation);
 		return invocation;
 	}
 }

--- a/Source/Mockerade/Mock.cs
+++ b/Source/Mockerade/Mock.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Mockerade.Checks;
 using Mockerade.Events;
 using Mockerade.Exceptions;
+using Mockerade.Monitor;
 using Mockerade.Setup;
 using static Mockerade.BaseClass;
 
@@ -28,11 +29,6 @@ public abstract class Mock<T> : IMock
 	}
 
 	/// <summary>
-	///     Check which methods got invoked on the mocked instance for <typeparamref name="T"/>.
-	/// </summary>
-	public MockInvoked<T> Invoked { get; }
-
-	/// <summary>
 	///     Check which properties were accessed on the mocked instance for <typeparamref name="T"/>.
 	/// </summary>
 	public MockAccessed<T> Accessed { get; }
@@ -41,6 +37,11 @@ public abstract class Mock<T> : IMock
 	///     Check which events were subscribed or unsubscribed on the mocked instance for <typeparamref name="T"/>.
 	/// </summary>
 	public MockEvent<T> Event { get; }
+
+	/// <summary>
+	///     Check which methods got invoked on the mocked instance for <typeparamref name="T"/>.
+	/// </summary>
+	public MockInvoked<T> Invoked { get; }
 
 	/// <summary>
 	///     Exposes the mocked object instance of type <typeparamref name="T"/>.
@@ -56,6 +57,11 @@ public abstract class Mock<T> : IMock
 	///     Sets up the mock for <typeparamref name="T"/>.
 	/// </summary>
 	public MockSetups<T> Setup { get; }
+
+	public MockMonitor<T> Monitor()
+	{
+		return new MockMonitor<T>(((IMock)this).Invocations);
+	}
 
 	#region IMock
 

--- a/Source/Mockerade/Mock.cs
+++ b/Source/Mockerade/Mock.cs
@@ -58,11 +58,6 @@ public abstract class Mock<T> : IMock
 	/// </summary>
 	public MockSetups<T> Setup { get; }
 
-	public MockMonitor<T> Monitor()
-	{
-		return new MockMonitor<T>(((IMock)this).Invocations);
-	}
-
 	#region IMock
 
 	/// <summary>

--- a/Source/Mockerade/Monitor/MockMonitor.cs
+++ b/Source/Mockerade/Monitor/MockMonitor.cs
@@ -20,7 +20,7 @@ public abstract class MockMonitor
 	/// <summary>
 	///     The invocations that were recorded during the monitoring session.
 	/// </summary>
-	protected MockInvocations Invocations { get; } = new();
+	protected MockInvocations Invocations { get; }
 	private int _monitoringStart = -1;
 
 	/// <inheritdoc cref="MockMonitor{T}" />

--- a/Source/Mockerade/Monitor/MockMonitor.cs
+++ b/Source/Mockerade/Monitor/MockMonitor.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Mockerade.Checks;
+using static Mockerade.Checks.CheckResult;
+
+namespace Mockerade.Monitor;
+
+public class MockMonitor<T>
+{
+	/// <summary>
+	///     Check which properties were accessed on the mocked instance for <typeparamref name="T"/>.
+	/// </summary>
+	public MockAccessed<T> Accessed { get; }
+
+	/// <summary>
+	///     Check which events were subscribed or unsubscribed on the mocked instance for <typeparamref name="T"/>.
+	/// </summary>
+	public MockEvent<T> Event { get; }
+
+	/// <summary>
+	///     Check which methods got invoked on the mocked instance for <typeparamref name="T"/>.
+	/// </summary>
+	public MockInvoked<T> Invoked { get; }
+
+	private readonly MockInvocations _monitoredInvocations;
+
+	private readonly MockInvocations _invocations = new();
+	private int _monitoringStart = -1;
+
+	internal MockMonitor(MockInvocations invocations)
+	{
+		_monitoredInvocations = invocations;
+		Accessed = new MockAccessed<T>(_invocations);
+		Event = new MockEvent<T>(_invocations);
+		Invoked = new MockInvoked<T>(_invocations);
+	}
+
+	/// <summary>
+	///     Begins monitoring invocations and returns a scope that ends monitoring when disposed.
+	/// </summary>
+	/// <remarks>
+	///     Dispose the returned object to stop monitoring and finalize the session.
+	/// </remarks>
+	/// <returns>
+	///     An <see cref="IDisposable"/> that ends the monitoring session when disposed.
+	/// </returns>
+	public IDisposable Run()
+	{
+		_monitoringStart = _monitoredInvocations.Invocations.Count();
+		return new MonitorScope(() => this.Stop());
+	}
+
+	internal void Stop()
+	{
+		if (_monitoringStart >= 0)
+		{
+			foreach (var invocation in _monitoredInvocations.Invocations.Skip(_monitoringStart))
+			{
+				_invocations.RegisterInvocation(invocation);
+			}
+		}
+		_monitoringStart = -1;
+	}
+
+	private sealed class MonitorScope(Action callback) : IDisposable
+	{
+		public void Dispose()
+		{
+			callback();
+		}
+	}
+}

--- a/Source/Mockerade/Monitor/MockMonitor.cs
+++ b/Source/Mockerade/Monitor/MockMonitor.cs
@@ -1,13 +1,81 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Mockerade.Checks;
-using static Mockerade.Checks.CheckResult;
 
 namespace Mockerade.Monitor;
 
-public class MockMonitor<T>
+/// <summary>
+///     Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed
+///     properties, invoked methods, and event subscriptions.
+/// </summary>
+/// <remarks>
+///     Use this class to track and analyze interactions with a mock, such as which members were accessed or
+///     which events were subscribed to, during a test session. Monitoring is session-based; begin a session with the Run
+///     method and dispose the returned scope to finalize monitoring.
+/// </remarks>
+public abstract class MockMonitor
+{
+	private readonly MockInvocations _monitoredInvocations;
+
+	/// <summary>
+	///     The invocations that were recorded during the monitoring session.
+	/// </summary>
+	protected MockInvocations Invocations { get; } = new();
+	private int _monitoringStart = -1;
+
+	/// <inheritdoc cref="MockMonitor{T}" />
+	public MockMonitor(IMock mock)
+	{
+		_monitoredInvocations = mock.Invocations;
+		Invocations = new();
+	}
+
+	/// <summary>
+	///     Begins monitoring invocations and returns a scope that ends monitoring when disposed.
+	/// </summary>
+	/// <remarks>
+	///     Dispose the returned object to stop monitoring and finalize the session.
+	/// </remarks>
+	/// <returns>
+	///     An <see cref="IDisposable"/> that ends the monitoring session when disposed.
+	/// </returns>
+	public IDisposable Run()
+	{
+		_monitoringStart = _monitoredInvocations.Count;
+		return new MonitorScope(() => this.Stop());
+	}
+
+	internal void Stop()
+	{
+		if (_monitoringStart >= 0)
+		{
+			foreach (var invocation in _monitoredInvocations.Invocations.Skip(_monitoringStart))
+			{
+				Invocations.RegisterInvocation(invocation);
+			}
+		}
+		_monitoringStart = -1;
+	}
+
+	private sealed class MonitorScope(Action callback) : IDisposable
+	{
+		public void Dispose()
+		{
+			callback();
+		}
+	}
+}
+
+/// <summary>
+///     Provides monitoring capabilities for a mocked instance of the specified type, allowing inspection of accessed
+///     properties, invoked methods, and event subscriptions.
+/// </summary>
+/// <remarks>
+///     Use this class to track and analyze interactions with a mock, such as which members were accessed or
+///     which events were subscribed to, during a test session. Monitoring is session-based; begin a session with the Run
+///     method and dispose the returned scope to finalize monitoring.
+/// </remarks>
+public class MockMonitor<T> : MockMonitor
 {
 	/// <summary>
 	///     Check which properties were accessed on the mocked instance for <typeparamref name="T"/>.
@@ -24,51 +92,11 @@ public class MockMonitor<T>
 	/// </summary>
 	public MockInvoked<T> Invoked { get; }
 
-	private readonly MockInvocations _monitoredInvocations;
-
-	private readonly MockInvocations _invocations = new();
-	private int _monitoringStart = -1;
-
-	internal MockMonitor(MockInvocations invocations)
+	/// <inheritdoc cref="MockMonitor{T}" />
+	public MockMonitor(IMock mock) : base(mock)
 	{
-		_monitoredInvocations = invocations;
-		Accessed = new MockAccessed<T>(_invocations);
-		Event = new MockEvent<T>(_invocations);
-		Invoked = new MockInvoked<T>(_invocations);
-	}
-
-	/// <summary>
-	///     Begins monitoring invocations and returns a scope that ends monitoring when disposed.
-	/// </summary>
-	/// <remarks>
-	///     Dispose the returned object to stop monitoring and finalize the session.
-	/// </remarks>
-	/// <returns>
-	///     An <see cref="IDisposable"/> that ends the monitoring session when disposed.
-	/// </returns>
-	public IDisposable Run()
-	{
-		_monitoringStart = _monitoredInvocations.Invocations.Count();
-		return new MonitorScope(() => this.Stop());
-	}
-
-	internal void Stop()
-	{
-		if (_monitoringStart >= 0)
-		{
-			foreach (var invocation in _monitoredInvocations.Invocations.Skip(_monitoringStart))
-			{
-				_invocations.RegisterInvocation(invocation);
-			}
-		}
-		_monitoringStart = -1;
-	}
-
-	private sealed class MonitorScope(Action callback) : IDisposable
-	{
-		public void Dispose()
-		{
-			callback();
-		}
+		Accessed = new MockAccessed<T>(Invocations);
+		Event = new MockEvent<T>(Invocations);
+		Invoked = new MockInvoked<T>(Invocations);
 	}
 }

--- a/Source/Mockerade/Monitor/MockMonitor.cs
+++ b/Source/Mockerade/Monitor/MockMonitor.cs
@@ -41,6 +41,11 @@ public abstract class MockMonitor
 	/// </returns>
 	public IDisposable Run()
 	{
+		if (_monitoringStart >= 0)
+		{
+			throw new InvalidOperationException("Monitoring is already running. Dispose the previous scope before starting a new one.");
+		}
+
 		_monitoringStart = _monitoredInvocations.Count;
 		return new MonitorScope(() => this.Stop());
 	}

--- a/Source/Mockerade/Monitor/MockMonitorExtensions.cs
+++ b/Source/Mockerade/Monitor/MockMonitorExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace Mockerade.Monitor;
+
+/// <summary>
+///     Extension methods for <see cref="MockMonitor{T}"/>.
+/// </summary>
+public static class MockMonitorExtensions
+{
+	/// <summary>
+	///     Create a mock monitor for the given <paramref name="mock"/> instance.
+	/// </summary>
+	public static MockMonitor<T> Monitor<T>(this Mock<T> mock)
+	{
+		return new MockMonitor<T>(mock);
+	}
+}

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net10.0.txt
@@ -263,7 +263,8 @@ namespace Mockerade.Checks
     public class MockInvocations
     {
         public MockInvocations() { }
-        public System.Collections.Generic.IReadOnlyList<Mockerade.Checks.Invocation> Invocations { get; }
+        public int Count { get; }
+        public System.Collections.Generic.IEnumerable<Mockerade.Checks.Invocation> Invocations { get; }
         public bool IsAlreadyInvoked { get; }
     }
     public class MockInvoked<T> : Mockerade.Checks.IMockInvoked
@@ -318,6 +319,26 @@ namespace Mockerade.Exceptions
     {
         public MockNotSetupException(string message) { }
         public MockNotSetupException(string message, System.Exception innerException) { }
+    }
+}
+namespace Mockerade.Monitor
+{
+    public abstract class MockMonitor
+    {
+        public MockMonitor(Mockerade.IMock mock) { }
+        protected Mockerade.Checks.MockInvocations Invocations { get; }
+        public System.IDisposable Run() { }
+    }
+    public static class MockMonitorExtensions
+    {
+        public static Mockerade.Monitor.MockMonitor<T> Monitor<T>(this Mockerade.Mock<T> mock) { }
+    }
+    public class MockMonitor<T> : Mockerade.Monitor.MockMonitor
+    {
+        public MockMonitor(Mockerade.IMock mock) { }
+        public Mockerade.Checks.MockAccessed<T> Accessed { get; }
+        public Mockerade.Checks.MockEvent<T> Event { get; }
+        public Mockerade.Checks.MockInvoked<T> Invoked { get; }
     }
 }
 namespace Mockerade.Setup

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_net8.0.txt
@@ -263,7 +263,8 @@ namespace Mockerade.Checks
     public class MockInvocations
     {
         public MockInvocations() { }
-        public System.Collections.Generic.IReadOnlyList<Mockerade.Checks.Invocation> Invocations { get; }
+        public int Count { get; }
+        public System.Collections.Generic.IEnumerable<Mockerade.Checks.Invocation> Invocations { get; }
         public bool IsAlreadyInvoked { get; }
     }
     public class MockInvoked<T> : Mockerade.Checks.IMockInvoked
@@ -318,6 +319,26 @@ namespace Mockerade.Exceptions
     {
         public MockNotSetupException(string message) { }
         public MockNotSetupException(string message, System.Exception innerException) { }
+    }
+}
+namespace Mockerade.Monitor
+{
+    public abstract class MockMonitor
+    {
+        public MockMonitor(Mockerade.IMock mock) { }
+        protected Mockerade.Checks.MockInvocations Invocations { get; }
+        public System.IDisposable Run() { }
+    }
+    public static class MockMonitorExtensions
+    {
+        public static Mockerade.Monitor.MockMonitor<T> Monitor<T>(this Mockerade.Mock<T> mock) { }
+    }
+    public class MockMonitor<T> : Mockerade.Monitor.MockMonitor
+    {
+        public MockMonitor(Mockerade.IMock mock) { }
+        public Mockerade.Checks.MockAccessed<T> Accessed { get; }
+        public Mockerade.Checks.MockEvent<T> Event { get; }
+        public Mockerade.Checks.MockInvoked<T> Invoked { get; }
     }
 }
 namespace Mockerade.Setup

--- a/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
+++ b/Tests/Mockerade.Api.Tests/Expected/Mockerade_netstandard2.0.txt
@@ -249,7 +249,8 @@ namespace Mockerade.Checks
     public class MockInvocations
     {
         public MockInvocations() { }
-        public System.Collections.Generic.IReadOnlyList<Mockerade.Checks.Invocation> Invocations { get; }
+        public int Count { get; }
+        public System.Collections.Generic.IEnumerable<Mockerade.Checks.Invocation> Invocations { get; }
         public bool IsAlreadyInvoked { get; }
     }
     public class MockInvoked<T> : Mockerade.Checks.IMockInvoked
@@ -304,6 +305,26 @@ namespace Mockerade.Exceptions
     {
         public MockNotSetupException(string message) { }
         public MockNotSetupException(string message, System.Exception innerException) { }
+    }
+}
+namespace Mockerade.Monitor
+{
+    public abstract class MockMonitor
+    {
+        public MockMonitor(Mockerade.IMock mock) { }
+        protected Mockerade.Checks.MockInvocations Invocations { get; }
+        public System.IDisposable Run() { }
+    }
+    public static class MockMonitorExtensions
+    {
+        public static Mockerade.Monitor.MockMonitor<T> Monitor<T>(this Mockerade.Mock<T> mock) { }
+    }
+    public class MockMonitor<T> : Mockerade.Monitor.MockMonitor
+    {
+        public MockMonitor(Mockerade.IMock mock) { }
+        public Mockerade.Checks.MockAccessed<T> Accessed { get; }
+        public Mockerade.Checks.MockEvent<T> Event { get; }
+        public Mockerade.Checks.MockInvoked<T> Invoked { get; }
     }
 }
 namespace Mockerade.Setup

--- a/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
@@ -94,8 +94,8 @@ public sealed class MockMonitorTests
 		mock.Object.IsValid(1);
 		mock.Object.IsValid(2);
 		var disposable = monitor.Run();
-			mock.Object.IsValid(3);
-			mock.Object.IsValid(4);
+		mock.Object.IsValid(3);
+		mock.Object.IsValid(4);
 		disposable.Dispose();
 		mock.Object.IsValid(5);
 		mock.Object.IsValid(6);

--- a/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mockerade.Tests.Monitor;
+
+public sealed class MockMonitorTests
+{
+	[Fact]
+	public async Task Run_ShouldMonitorInvocationsDuringTheRun()
+	{
+		var mock = Mock.For<IMyService>();
+		var monitor = mock.Monitor();
+
+		mock.Object.IsValid(1);
+		mock.Object.IsValid(2);
+		using (monitor.Run())
+		{
+			mock.Object.IsValid(3);
+			mock.Object.IsValid(4);
+		}
+		mock.Object.IsValid(5);
+
+		await That(monitor.Invoked.IsValid(1).Never());
+		await That(monitor.Invoked.IsValid(2).Never());
+		await That(monitor.Invoked.IsValid(3).Once());
+		await That(monitor.Invoked.IsValid(4).Once());
+		await That(monitor.Invoked.IsValid(5).Never());
+		await That(mock.Invoked.IsValid(1).Once());
+		await That(mock.Invoked.IsValid(2).Once());
+		await That(mock.Invoked.IsValid(3).Once());
+		await That(mock.Invoked.IsValid(4).Once());
+		await That(mock.Invoked.IsValid(5).Once());
+	}
+
+	[Fact]
+	public async Task MultipleRun_ShouldMonitorInvocationsDuringTheRun()
+	{
+		var mock = Mock.For<IMyService>();
+		var monitor = mock.Monitor();
+
+		mock.Object.IsValid(1);
+		mock.Object.IsValid(2);
+		using (monitor.Run())
+		{
+			mock.Object.IsValid(3);
+			mock.Object.IsValid(4);
+		}
+		mock.Object.IsValid(5);
+		mock.Object.IsValid(6);
+		using (monitor.Run())
+		{
+			mock.Object.IsValid(7);
+			mock.Object.IsValid(8);
+		}
+		mock.Object.IsValid(9);
+		mock.Object.IsValid(10);
+
+		await That(monitor.Invoked.IsValid(1).Never());
+		await That(monitor.Invoked.IsValid(2).Never());
+		await That(monitor.Invoked.IsValid(3).Once());
+		await That(monitor.Invoked.IsValid(4).Once());
+		await That(monitor.Invoked.IsValid(5).Never());
+		await That(monitor.Invoked.IsValid(6).Never());
+		await That(monitor.Invoked.IsValid(7).Once());
+		await That(monitor.Invoked.IsValid(8).Once());
+		await That(monitor.Invoked.IsValid(9).Never());
+		await That(monitor.Invoked.IsValid(10).Never());
+	}
+
+	[Fact]
+	public async Task DisposeTwice_ShouldNotIncludeMoreInvocations()
+	{
+		var mock = Mock.For<IMyService>();
+		var monitor = mock.Monitor();
+
+		mock.Object.IsValid(1);
+		mock.Object.IsValid(2);
+		var disposable = monitor.Run();
+			mock.Object.IsValid(3);
+			mock.Object.IsValid(4);
+		disposable.Dispose();
+		mock.Object.IsValid(5);
+		mock.Object.IsValid(6);
+		disposable.Dispose();
+		mock.Object.IsValid(7);
+		mock.Object.IsValid(8);
+
+		await That(monitor.Invoked.IsValid(1).Never());
+		await That(monitor.Invoked.IsValid(2).Never());
+		await That(monitor.Invoked.IsValid(3).Once());
+		await That(monitor.Invoked.IsValid(4).Once());
+		await That(monitor.Invoked.IsValid(5).Never());
+		await That(monitor.Invoked.IsValid(6).Never());
+		await That(monitor.Invoked.IsValid(7).Never());
+		await That(monitor.Invoked.IsValid(8).Never());
+	}
+
+	public interface IMyService
+	{
+		bool IsValid(int id);
+	}
+}

--- a/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
@@ -67,6 +67,25 @@ public sealed class MockMonitorTests
 	}
 
 	[Fact]
+	public async Task NestedRun_ShouldThrowInvalidOperationException()
+	{
+		var mock = Mock.For<IMyService>();
+		var monitor = mock.Monitor();
+
+		void Act()
+			=> monitor.Run();
+
+		var outerRun = monitor.Run();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("Monitoring is already running. Dispose the previous scope before starting a new one.");
+
+		outerRun.Dispose();
+
+		await That(Act).DoesNotThrow();
+	}
+
+	[Fact]
 	public async Task DisposeTwice_ShouldNotIncludeMoreInvocations()
 	{
 		var mock = Mock.For<IMyService>();

--- a/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
+++ b/Tests/Mockerade.Tests/Monitor/MockMonitorTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Mockerade.Monitor;
 
 namespace Mockerade.Tests.Monitor;
 


### PR DESCRIPTION
Adds a monitoring feature to validate only the invocations that occur within a defined scope on a mock instance.

### Key changes:
- Introduces `MockMonitor<T>` with `Run()` to capture a subset of invocations.
- Adds extension to create a mock monitor from a `Mock<T>` instance.
- Adds tests covering single run, multiple runs, and double-dispose behavior.
- Changes MockInvocations to store indexed invocations and exposes them as IEnumerable.

---

- *Fixes #55*